### PR TITLE
chore: atualizar caixinha-core para 1.2.2

### DIFF
--- a/caixinha-serverless/package-lock.json
+++ b/caixinha-serverless/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@sentry/node": "^7.54.0",
         "amqplib": "^0.10.3",
-        "caixinha-core": "^1.2.1",
+        "caixinha-core": "^1.2.2",
         "moment": "^2.29.4",
         "mongodb": "^5.4.0"
       },
@@ -1598,10 +1598,13 @@
       "license": "MIT"
     },
     "node_modules/caixinha-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/caixinha-core/-/caixinha-core-1.2.1.tgz",
-      "integrity": "sha512-vdS6EZ8z2mvftJn+CoVRR0Hal1pGQbCuuTAjmfnz1RwNVlrRIiTXYEQBW7FETnli1uvdny+sIdhcHLbRw1morQ==",
-      "license": "ISC"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/caixinha-core/-/caixinha-core-1.2.2.tgz",
+      "integrity": "sha512-bWpQpp+YkkojymgP5xIRXlQemBKuYhK739244qAsErL3mM0TWrmWjA3ZH1oVd8/6kjZKCV2HDW3m07CaZI2tWQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=23"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",

--- a/caixinha-serverless/package.json
+++ b/caixinha-serverless/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@sentry/node": "^7.54.0",
     "amqplib": "^0.10.3",
-    "caixinha-core": "^1.2.1",
+    "caixinha-core": "^1.2.2",
     "moment": "^2.29.4",
     "mongodb": "^5.4.0"
   },


### PR DESCRIPTION
## Summary

- Atualiza dependência `caixinha-core` de `^1.2.1` para `^1.2.2` em `caixinha-serverless/package.json`
- Versão 1.2.2 publicada em 2026-05-28T21:46:50.219Z (shasum: `62c738a89f1480e77d8881f3c2275ce8caea5c5e`)

https://claude.ai/code/session_01EAoHtomMzQgZ8x7t1btSyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAoHtomMzQgZ8x7t1btSyw)_