### PR TITLE
feat(design): redesign visual das telas principais com sistema Indigo

### DIFF
--- a/front-caixinha/DESIGN_TASKS.md
+++ b/front-caixinha/DESIGN_TASKS.md
@@ -1,0 +1,265 @@
+# Redesign Tasks — Caixinha (Indigo)
+
+Fonte de design: `caixinha-repaginada/project/Caixinha - Telas (Indigo).html`
+Paleta principal: indigo `#6366F1`, fundo branco, tipografia Plus Jakarta Sans + Inter.
+Raio de card: 20px | sombra: `0 5px 22px rgba(0,0,0,0.08)` | botão: radius 12px.
+
+> **Regra geral:** antes de alterar qualquer tela, ler TODA a página e seus componentes filhos.
+> Nunca quebrar lógica de negócio — só alterar a camada visual (layout, espaçamentos, cores, tipografia).
+> Manter todos os hooks, handlers, chamadas de API e navegação intactos.
+
+---
+
+## Status
+
+| # | Tela | Arquivo | Status |
+|---|------|---------|--------|
+| 01 | Home / Dashboard | `src/pages/index.tsx` | ✅ concluído |
+| 02 | Caixinhas disponíveis | `src/pages/caixinhas-disponiveis/index.tsx` | ✅ concluído |
+| 03 | Minha Caixinha (detalhe) | `src/pages/caixinha/[id].tsx` | ✅ concluído |
+| 04 | Empréstimo | `src/pages/emprestimo/index.tsx` | ✅ concluído |
+| 05 | Depósito | `src/pages/deposito/index.tsx` | ✅ concluído |
+| 06 | Extrato | `src/pages/extrato/index.tsx` | ✅ concluído |
+| 07 | Feed | `src/pages/feed/index.tsx` | ✅ concluído |
+
+---
+
+## TASK-01 — Home / Dashboard
+
+**Arquivo:** `src/pages/index.tsx`
+
+### Design alvo (indigo/screens.jsx → `HomeScreen`)
+- Título h3 "Bem-vindo à Caixinha!" centralizado, fontWeight 700, fontSize 34.
+- Primeira linha: `BannerNovidades` (1.4fr) + `Dicas` (1fr) com `gap: 24px` — ambos stretching em altura.
+- Segunda linha: grid `repeat(auto-fit, minmax(240px, 1fr))` com 4 `GradientCard`s:
+  - "Minha caixinha" → `/caixinha/{id}` (só aparece se `caixinha?.id` existir)
+  - "Caixinhas" → `/caixinhas-disponiveis`
+  - "Depositar" → `/deposito`
+  - "Pedir empréstimo" → `/emprestimo`
+- Cada GradientCard: gradiente indigo do array `GRADIENTS`, ícone MUI 36px branco, título h5 branco, descrição body2 branco, hover `translateY(-4px) scale(1.03)`.
+
+### Funcionalidade a preservar
+- `useCaixinhaSelect()` → `caixinha` (card "Minha caixinha" só renderiza se `caixinha?.id` existir).
+- `useUltimoEmprestimoPendente()` → quando `ultimoEmprestimoAtalho?.exists` é true, substituir o card `Dicas` por `AtalhoEmprestimo`.
+- `useSettings()` → `settings.stretch` para `Container maxWidth`.
+- `useTranslation()` → textos i18n nos cards.
+- Toda navegação `router.push(...)` deve continuar funcionando.
+
+### O que mudar
+- Substituir o Grid `md={7}` / `md={5}` por `gridTemplateColumns: '1.4fr 1fr'` com CSS grid nativo (ou MUI Box com `display:'grid'`).
+- Substituir os cards individuais em `Grid xs={12} md={7}` por um grid `repeat(auto-fit,minmax(240px,1fr))`.
+- Atualizar o estilo dos cards inline para usar a paleta indigo e o array de gradientes existente `corAleatoriaCombinada()`.
+- Trocar ícones MUI `SvgIcon` por ícones inline dentro do card (já existe `DashboardIcon`, `SavingsIcon` etc — mantê-los).
+- `py: 8` → `padding: '40px 24px 64px'` (ou equivalente).
+
+---
+
+## TASK-02 — Caixinhas disponíveis
+
+**Arquivo:** `src/pages/caixinhas-disponiveis/index.tsx`
+
+### Design alvo (indigo/screens.jsx → `CaixinhasScreen`)
+- Overline "Comunidade" (fontSize 12, uppercase, letterSpacing 0.5px, cor textSecondary).
+- Título h4 "Caixinhas disponíveis", fontWeight 700, fontSize 28.
+- Grid `repeat(auto-fill, minmax(260px, 1fr))` gap 24px.
+- Cada `CaixinhaCard`: header colorido 140px (gradiente), valor em destaque, nome, footer com "Detalhes" + contador de membros + botão "Participar".
+
+### Funcionalidade a preservar
+- `useCaixinhasCatalog()` → `{ catalog, isLoading, error }`.
+- `filterCaixinhasByQuery(catalog, query)` → `data`.
+- Paginação por `PAGE_SIZE = 6` com `Pagination`.
+- `CaixinhaSearch` → campo de busca.
+- `CenteredCircularProgress` no loading.
+- `router.push('/error')` no erro.
+
+### O que mudar
+- Remover o wrapper duplo `Paper` externo.
+- Substituir o título `Typography variant="h3"` por overline + h4 alinhados à esquerda.
+- Substituir o `Paper` ao redor do grid por um `Box` simples.
+- Mover `CaixinhaSearch` para above the grid, sem Paper wrapper extra.
+- Ajustar o `CaixinhaCard` existente em `src/components/caixinha/CaixinhaCard.tsx` para ter header colorido 140px e footer com layout do design (ler o componente antes de alterar).
+
+---
+
+## TASK-03 — Minha Caixinha (detalhe)
+
+**Arquivo:** `src/pages/caixinha/[id].tsx`
+
+### Design alvo (indigo/screens-extra.jsx → `MinhaCaixinhaScreen`)
+- Overline "Minha caixinha", título h4 com nome da caixinha, fontWeight 700.
+- 3 `StatCard`s em grid `repeat(auto-fit, minmax(230px, 1fr))`:
+  - Saldo da caixinha (com `difference` do CDI, ícone savings).
+  - Participantes (sem delta).
+  - Empréstimos ativos (com delta negativo se houver).
+- Barra de ações: botão "Depositar" (contained), "Pedir empréstimo" (outlined), "Extrato" (text), "Análise completa" (text).
+- `UltimasMovimentacoes` / `ExtratoTable` abaixo.
+
+### Funcionalidade a preservar
+- Todas as verificações de autenticação (`sessionStatus === 'unauthenticated'`).
+- Verificação de `!mine` (usuário não participa).
+- `useMinhasCaixinhas()`, `useAnaliseCaixinha()`, `useCaixinhaContext()`.
+- Toda a lógica de `saldoFromCaixinha(c)`.
+- Botões com `component={Link}` preservando hrefs e query params.
+- `CenteredCircularProgress` nos estados de loading.
+
+### O que mudar
+- Substituir os 4 `CardTotal` por `StatCard` com estilo do design (Avatar 56px com ícone, overline, valor em fontSize 30, delta opcional).
+- Ajustar tipografia do título para overline + h4.
+- Remover o botão "Início" (`ArrowBackIos`) e colocá-lo como link discreto acima do overline.
+- Ajustar o layout dos botões de ação para `display: flex, gap: 12, flexWrap: wrap`.
+
+---
+
+## TASK-04 — Empréstimo
+
+**Arquivo:** `src/pages/emprestimo/index.tsx`
+
+### Design alvo (indigo/screens-extra.jsx → `EmprestimoScreen`)
+- Layout 2 colunas `minmax(0,1fr) minmax(0,1fr)` gap 24.
+- Card esquerdo — formulário visual:
+  - Overline "Valor solicitado" + valor grande em `#6366F1` (fontSize 30, fontWeight 700).
+  - Slider `input[type=range]` min=100 max=5000 step=100, accentColor indigo.
+  - Overline "Parcelamento" + 4 botões (2x / 3x / 6x / 12x) com borda indigo quando selecionado.
+  - Campo de texto "Motivo" (já existe).
+- Card direito — resumo:
+  - Título "Resumo".
+  - Linhas: Valor solicitado / Taxas / Juros.
+  - Divisor + Total a pagar em destaque indigo.
+  - Linha "N× de R$ X".
+  - Botão "Solicitar empréstimo" (full, large, contained).
+
+### Funcionalidade a preservar
+- `doEmprestimo({ ...solicitacao, motivo, caixinhaID })` → `router.push('/sucesso')`.
+- `getValorParcelas({ parcelas, total })` → `stateParcelas`.
+- `useUserAuth()` para `user.name` e `user.email` no state.
+- `useCaixinhaSelect()` para `caixinha?.id` e `caixinha?.name`.
+- `toast.error(err.message)` no catch.
+- `CenteredCircularProgress` no isLoading.
+
+### O que mudar
+- Substituir `OutlinedInput` de valor por slider + display de valor grande.
+- Substituir `OutlinedInput` de parcela por botões selecionáveis (mantendo o state `solicitacao.parcela`).
+- Manter `OutlinedInput` de juros (necessário pois o backend precisa) — pode ficar como campo secundário ou dentro do resumo.
+- Manter campo de motivo como `OutlinedInput multiline`.
+- O cálculo de total/parcela do design é local (visual) — o real vem de `getValorParcelas`, que deve continuar sendo chamado.
+
+---
+
+## TASK-05 — Depósito
+
+**Arquivo:** `src/pages/deposito/index.tsx`
+
+### Design alvo (indigo/new-screens.jsx → `DepositoScreen`)
+- Layout 2 colunas `minmax(0,1.3fr) minmax(0,1fr)`.
+- Card esquerdo:
+  - Select "Depositar na caixinha" (somente visual — caixinha já vem do context, manter readonly ou disabled).
+  - Input de valor com "R$" em destaque (fontSize 30 fontHead) + borda indigo.
+  - 4 botões rápidos: +R$50 / +R$100 / +R$200 / +R$500.
+  - 3 botões de método de pagamento (Pix / Cartão / Boleto) com radio visual.
+  - Upload de comprovante (mantido como está, mas com visual melhorado).
+- Card direito — resumo sticky:
+  - Linhas: Caixinha / Valor / Taxa.
+  - Divisor + Total em indigo.
+  - Badge verde "Transação protegida".
+  - Botão "Depositar R$ X" (full, large, contained).
+- QR Code PIX: manter mas posicionar abaixo dos métodos ou como modal (não remover).
+
+### Funcionalidade a preservar
+- `doDeposito({ caixinhaId, name, email, valor, comprovante })` → `router.push('/sucesso/deposito')`.
+- `getChavesPix(caixinha.id)` → `pix.chave` e `pix.url` (QR code).
+- `uploadResource(file)` → `solicitacao.fileUrl`.
+- `getBuckets()` chamado no mount.
+- Chips de comprovante com status de upload.
+- `toast.loading / toast.success / toast.error`.
+- `useUserAuth()` → memberName / email (disabled).
+- `useCaixinhaSelect()` → caixinha.
+
+### O que mudar
+- Substituir layout 2-coluna atual por grid com proporção 1.3fr / 1fr.
+- Adicionar botões de valor rápido (+50/+100/+200/+500) acima do campo valor.
+- Adicionar seletor visual de método de pagamento.
+- Colocar QR Code PIX como expansível dentro da opção "Pix" selecionada.
+- Card de resumo com badge de proteção + botão CTA.
+- Remover campo "Mensagem" (não é enviado ao backend).
+
+---
+
+## TASK-06 — Extrato
+
+**Arquivo:** `src/pages/extrato/index.tsx`
+
+### Design alvo (indigo/screens-extra.jsx → `ExtratoTable` + `ExtratoScreen`)
+- Overline "Movimentações", título h4 "Extrato".
+- Filtros: chips de filtro mantidos, mas acima da tabela com layout mais discreto.
+- Tabela com 5 colunas: Operação / Membro / Data / Valor / Status.
+- Na coluna Operação: avatar 32px com ícone seta ↓ (verde, depósito) ou ↑ (laranja, empréstimo) + texto.
+- Valor: cor verde para entradas (`+`), cor texto normal para saídas (`−`).
+- Status: `Chip` soft (warning=Pendente, success=Concluído, primary=Quitado).
+- Header de coluna: uppercase, fontSize 12, letterSpacing 0.5px, cor textSecondary.
+
+### Funcionalidade a preservar
+- `useExtrato(extratoParams)` → `{ linhas, isLoading, error }`.
+- Filtros via `router.query` (meu/dep/emp/id) com `patchQuery`.
+- `useSession()` para `user.name`.
+- Skeleton loading com 8 linhas.
+- `router.push('/error')` no erro.
+- `Pagination` (mesmo que `count=1` por ora).
+- `DisplayValorMonetario` para exibição de valores.
+
+### O que mudar
+- Substituir header da tabela por cells com estilo uppercase + letterSpacing.
+- Na coluna Operação, adicionar avatar colorido com ícone (inferir tipo de `order.tipo`: "Depósito" → `arrow_downward` verde, "Empréstimo" → `arrow_upward` laranja).
+- Na coluna Valor, colorir de verde quando entrada (quando `order.tipo === 'Depósito'`).
+- Substituir o texto puro de status por `Chip` com cor dinâmica (success/warning/primary).
+- Ajustar overline + título acima da tabela.
+- Manter chips de filtro mas ajustar visual (gap, spacing).
+
+---
+
+## TASK-07 — Feed
+
+**Arquivo:** `src/pages/feed/index.tsx`
+
+### Design alvo (indigo/screens.jsx → `FeedScreen`)
+- Container maxWidth 620.
+- Overline "Social", título h4 "Feed", subtitle "Aqui está o que suas conexões postaram".
+- Card compositor (textarea + botão "Publicar").
+- Lista de `FeedPost` cards: avatar, nome, tempo, texto, chip de ativo (quando houver), botões curtir/comentar/compartilhar.
+
+### Funcionalidade a preservar
+- `getMeuFeed(username)` → `posts` com paginação via `page`.
+- `loadMore()` → append de posts.
+- `addCommentView(comment, postId)` → atualiza `posts` localmente.
+- `useUserAuth()` para `user.name`, `user.photoUrl`, `user.email`.
+- `SocialPostAdd` → manter componente de composição de posts (já tem submit para backend).
+- `SocialPostCard` → manter, mas aplicar visual do design ao redor (Card wrapper).
+- `hasMore` → botão "Carregar mais".
+- `useTranslation()` para labels.
+
+### O que mudar
+- Reduzir `Container maxWidth="lg"` para `maxWidth="sm"` (ou Box maxWidth 620).
+- Adicionar overline "Social" acima do título.
+- Adicionar subtitle de texto secundário abaixo do título.
+- `SocialPostCard` pode receber o visual de `FeedPost` — ler o componente antes de alterar.
+- Ajustar `py: 8` para `padding: '40px 24px 64px'`.
+
+---
+
+## Componentes compartilhados a criar/ajustar
+
+| Componente | Ação |
+|-----------|------|
+| `src/components/caixinha/CaixinhaCard.tsx` | Adicionar header colorido 140px + footer layout (TASK-02) |
+| `src/components/analise-caixinha/card-total.tsx` | Avaliar se `StatCard` do design substitui ou coexiste (TASK-03) |
+
+---
+
+## Ordem sugerida de implementação
+
+1. TASK-01 (Home) — mais visível, menor risco
+2. TASK-02 (Caixinhas) — grid/cards, sem lógica complexa
+3. TASK-06 (Extrato) — apenas visual da tabela
+4. TASK-03 (Minha Caixinha) — stat cards + ações
+5. TASK-04 (Empréstimo) — substituição de inputs por slider
+6. TASK-05 (Depósito) — maior complexidade (QR + upload)
+7. TASK-07 (Feed) — ajuste de container + overline

--- a/front-caixinha/src/components/analise-caixinha/card-total.tsx
+++ b/front-caixinha/src/components/analise-caixinha/card-total.tsx
@@ -1,85 +1,81 @@
 import { ArrowDownward, ArrowUpward, SavingsRounded } from '@mui/icons-material';
-import { Avatar, Card, CardContent, Stack, SvgIcon, Typography } from '@mui/material';
+import { Avatar, Box, Card, Stack, SvgIcon, Typography } from '@mui/material';
 import DisplayValorMonetario from '../display-valor-monetario';
 
 export const CardTotal = (props: any) => {
-  const { 
-    difference, 
-    positive = false, 
-    sx, 
+  const {
+    difference,
+    positive = false,
+    sx,
     value,
     displayText = '',
     displayText2 = '',
     icon = (<SavingsRounded />)
-} = props;
+  } = props;
 
   return (
-    <Card sx={sx}>
-      <CardContent>
-        <Stack
-          alignItems="flex-start"
-          direction="row"
-          justifyContent="space-between"
-          spacing={3}
+    <Card
+      sx={{
+        borderRadius: 5,
+        boxShadow: '0 5px 22px rgba(0,0,0,0.08)',
+        p: 3,
+        ...sx,
+      }}
+    >
+      <Stack
+        alignItems="flex-start"
+        direction="row"
+        justifyContent="space-between"
+        spacing={1.5}
+      >
+        <Box>
+          <Typography
+            color="text.secondary"
+            variant="overline"
+            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', lineHeight: 2 }}
+          >
+            {displayText}
+          </Typography>
+          <DisplayValorMonetario
+            variant="h5"
+            sx={{ fontWeight: 600, fontSize: 28, mt: 0.5 }}
+          >
+            {value}
+          </DisplayValorMonetario>
+        </Box>
+        <Avatar
+          sx={{
+            bgcolor: 'primary.main',
+            height: 56,
+            width: 56,
+            flexShrink: 0,
+          }}
         >
-          <Stack spacing={1}>
-            <Typography
-              color="text.secondary"
-              variant="overline"
-            >
-              {displayText}
-            </Typography>
-            <DisplayValorMonetario
-              variant="h4">
-              {value}
-            </DisplayValorMonetario>
-          </Stack>
-          <Avatar
-            sx={{
-              backgroundColor: (theme) => theme.palette.primary.main,
-              height: 56,
-              width: 56
-            }}
-          >
-            <SvgIcon>
-              {icon}
+          <SvgIcon>{icon}</SvgIcon>
+        </Avatar>
+      </Stack>
+
+      {difference && (
+        <Stack alignItems="center" direction="row" spacing={1} sx={{ mt: 2 }}>
+          <Stack alignItems="center" direction="row" spacing={0.5}>
+            <SvgIcon color={positive ? 'success' : 'error'} fontSize="small">
+              {positive ? <ArrowUpward /> : <ArrowDownward />}
             </SvgIcon>
-          </Avatar>
-        </Stack>
-        {difference && (
-          <Stack
-            alignItems="center"
-            direction="row"
-            spacing={2}
-            sx={{ mt: 2 }}
-          >
-            <Stack
-              alignItems="center"
-              direction="row"
-              spacing={0.5}
-            >
-              <SvgIcon
-                color={positive ? 'success' : 'error'}
-                fontSize="small"
-              >
-                {positive ? <ArrowUpward /> : <ArrowDownward />}
-              </SvgIcon>
-              <Typography
-                color={positive ? 'success.main' : 'error.main'}
-                variant="body2"
-              >
-                {difference}%
-              </Typography>
-            </Stack>
             <Typography
-              color="text.secondary"
-              variant="caption"
+              color={positive ? 'success.main' : 'error.main'}
+              variant="body2"
+              fontWeight={500}
             >
+              {difference}%
+            </Typography>
+          </Stack>
+          {displayText2 && (
+            <Typography color="text.secondary" variant="caption">
               {displayText2}
             </Typography>
-          </Stack>
-        )}
-      </CardContent>
+          )}
+        </Stack>
+      )}
     </Card>
   );
 };

--- a/front-caixinha/src/components/caixinha/CaixinhaCard.tsx
+++ b/front-caixinha/src/components/caixinha/CaixinhaCard.tsx
@@ -1,22 +1,22 @@
 import { Caixinha } from '@/types/types';
 import { InfoOutlined, PeopleAltOutlined } from '@mui/icons-material';
-import { Box, Button, Card, CardContent, CardMedia, Divider, IconButton, Stack, SvgIcon, Typography } from '@mui/material';
+import { Box, Button, Card, Divider, Stack, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
 import DisplayValorMonetario from '../display-valor-monetario';
 import { getAleatorio } from '@/utils/utils';
 
-const images = [
-    'https://static.vecteezy.com/system/resources/previews/001/759/904/original/crowdfunding-isometric-web-banner-vector.jpg',
-    'https://www.siteware.com.br/wp-content/uploads/2018/07/colaboracao-ambiente-de-trabalho.png',
-    'https://www.siteware.com.br/wp-content/uploads/2018/12/colaboracao-corporativa.png',
-    'https://www.napratica.org.br/wp-content/uploads/2020/07/btg.jpg',
-    'https://i.pinimg.com/736x/e7/5f/ce/e75fcea304308f2718b188c027a58a2d.jpg',
-    'https://www.comececomopedireito.com.br/blog/wp-content/uploads/2021/03/Investimentos-para-empresas.jpg'
+const GRADIENTS = [
+    'linear-gradient(135deg,#5475B8,#7691C6)',
+    'linear-gradient(135deg,#9176C6,#C7B9E1)',
+    'linear-gradient(135deg,#7A86B2,#A2A9CD)',
+    'linear-gradient(135deg,#6B82A3,#B3B1D4)',
+    'linear-gradient(135deg,#868DB6,#C8C4E5)',
+    'linear-gradient(135deg,#8988B8,#AFAEE1)',
 ]
 
 export const CaixinhaCard = ({ caixinha }: { caixinha: Caixinha }) => {
     const router = useRouter()
-    const imagemAleatoria = getAleatorio(images)
+    const gradient = getAleatorio(GRADIENTS)
 
     const join = () => {
         router.push({
@@ -37,78 +37,66 @@ export const CaixinhaCard = ({ caixinha }: { caixinha: Caixinha }) => {
             sx={{
                 display: 'flex',
                 flexDirection: 'column',
-                height: '100%'
+                height: '100%',
+                borderRadius: 5,
+                boxShadow: '0 5px 22px rgba(0,0,0,0.08)',
+                overflow: 'hidden',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                '&:hover': {
+                    transform: 'translateY(-4px)',
+                    boxShadow: '0 10px 32px rgba(0,0,0,0.14)',
+                },
             }}
         >
-            <CardMedia
-                image={imagemAleatoria}
-                sx={{ height: 180 }}
-            />
-            <CardContent>
-              
+            {/* Gradient header — replaces random external image */}
+            <Box sx={{ height: 140, background: gradient }} />
+
+            <Box sx={{ p: 3, textAlign: 'center' }}>
                 <DisplayValorMonetario
                     align="center"
                     gutterBottom
                     variant="h5"
+                    sx={{ fontWeight: 700 }}
                 >
                     {caixinha.currentBalance.value.toFixed(2)}
                 </DisplayValorMonetario>
-                <Typography
-                    align="center"
-                    variant="body1"
-                >
+                <Typography align="center" variant="body1" color="text.primary">
                     {caixinha.name}
                 </Typography>
-            </CardContent>
+            </Box>
+
             <Box sx={{ flexGrow: 1 }} />
             <Divider />
+
             <Stack
                 alignItems="center"
                 direction="row"
                 justifyContent="space-between"
-                spacing={2}
-                sx={{ p: 2 }}
+                sx={{ px: 2, py: 1.5 }}
             >
-                <Stack
-                    alignItems="center"
-                    direction="row"
-                    spacing={1}
+                <Button
+                    size="small"
+                    color="inherit"
+                    startIcon={<InfoOutlined fontSize="small" />}
+                    onClick={detalhes}
+                    sx={{ color: 'text.secondary', textTransform: 'none', fontSize: 13 }}
                 >
-                    <IconButton onClick={detalhes}>
-                        <SvgIcon
-                            color="action"
-                            fontSize="small"
-                        >
-                            <InfoOutlined />
-                        </SvgIcon>
-                        <Typography
-                            color="text.secondary"
-                            display="inline"
-                            variant="body2"
-                        >
-                             Detalhes
+                    Detalhes
+                </Button>
+
+                <Stack alignItems="center" direction="row" spacing={1.5}>
+                    <Stack alignItems="center" direction="row" spacing={0.5}>
+                        <PeopleAltOutlined sx={{ fontSize: 18, color: 'text.secondary' }} />
+                        <Typography color="text.secondary" variant="body2">
+                            {caixinha.members.length}
                         </Typography>
-                    </IconButton>
-                </Stack>
-                <Stack
-                    alignItems="center"
-                    direction="row"
-                    spacing={1}
-                >
-                    <SvgIcon
-                        color="action"
-                        fontSize="small"
-                    >
-                        <PeopleAltOutlined />
-                    </SvgIcon>
-                    <Typography
-                        color="text.secondary"
-                        display="inline"
-                        variant="body2"
-                    >
-                        {caixinha.members.length} Participantes
-                    </Typography>
-                    <Button onClick={join}
+                    </Stack>
+                    <Button
+                        size="small"
+                        variant="text"
+                        color="primary"
+                        onClick={join}
+                        sx={{ textTransform: 'none', fontWeight: 600 }}
                     >
                         Participar
                     </Button>

--- a/front-caixinha/src/locales/translations/en.ts
+++ b/front-caixinha/src/locales/translations/en.ts
@@ -73,6 +73,7 @@ export const en = {
     ["data"]: "Date",
     ["status"]: "Status",
     ["value"]: "Value",
+    ["extrato_filtros.movimentacoes"]: "Movements",
     ["extrato_filtros.todo_mundo"]: "From everyone",
     ["extrato_filtros.somente_meu"]: "Only mine",
     ["extrato_filtros.remover_depositos"]: "Remove deposits",

--- a/front-caixinha/src/locales/translations/pt.ts
+++ b/front-caixinha/src/locales/translations/pt.ts
@@ -73,6 +73,7 @@ export const pt = {
     ["data"]: "Data",
     ["status"]: "Status",
     ["value"]: "Valor",
+    ["extrato_filtros.movimentacoes"]: "Movimentações",
     ["extrato_filtros.todo_mundo"]: "De todo mundo",
     ["extrato_filtros.somente_meu"]: "Somente meu",
     ["extrato_filtros.remover_depositos"]: "Remover depositos",

--- a/front-caixinha/src/pages/caixinha/[id].tsx
+++ b/front-caixinha/src/pages/caixinha/[id].tsx
@@ -157,7 +157,7 @@ export default function CaixinhaHubPage() {
   return (
     <Layout>
       <Seo title={nome} />
-      <Box component="main" sx={{ flexGrow: 1, py: { xs: 3, md: 6 } }}>
+      <Box component="main" sx={{ flexGrow: 1, py: { xs: 5, md: 8 } }}>
         <Container maxWidth="lg">
           <Stack spacing={3}>
             <Button
@@ -169,15 +169,19 @@ export default function CaixinhaHubPage() {
             >
               Início
             </Button>
-            <Stack spacing={1}>
-              <Typography variant="h4" fontWeight={700}>
+            <Box>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', lineHeight: 2 }}
+              >
+                Minha caixinha
+              </Typography>
+              <Typography variant="h4" fontWeight={700} sx={{ mt: 0.5 }}>
                 {nome}
               </Typography>
-              <Typography color="text.secondary" variant="body1">
-                Saldo na caixinha (cadastro): {saldoFromCaixinha(mine)}
-              </Typography>
-            </Stack>
-            <Stack direction="row" flexWrap="wrap" gap={1}>
+            </Box>
+            <Stack direction="row" flexWrap="wrap" gap={1.5}>
               <Button
                 variant="contained"
                 startIcon={<AccountBalanceWalletIcon />}

--- a/front-caixinha/src/pages/caixinhas-disponiveis/index.tsx
+++ b/front-caixinha/src/pages/caixinhas-disponiveis/index.tsx
@@ -3,8 +3,6 @@ import {
   Box,
   Container,
   Pagination,
-  Stack,
-  Paper
 } from '@mui/material'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import Layout from '@/components/Layout'
@@ -13,18 +11,16 @@ import { CaixinhaSearch } from '@/components/caixinha/CaixinhaSearch'
 import { CaixinhaCard } from '@/components/caixinha/CaixinhaCard'
 import CenteredCircularProgress from '@/components/CenteredCircularProgress'
 import { useRouter } from 'next/router'
-import Grid from '@mui/material/Unstable_Grid2';
 import { Footer } from '@/components/footer'
-import { useTheme } from '@mui/material/styles';
 import { useCaixinhasCatalog } from '@/features/caixinha/hooks/useCaixinhasCatalog'
 import { filterCaixinhasByQuery } from '@/features/caixinha/api/caixinha.api'
+
 const PAGE_SIZE = 6
 
 export default function Home() {
   const [query, setQuery] = useState('')
   const [page, setPage] = useState(1)
   const router = useRouter()
-  const theme = useTheme()
   const { catalog, isLoading, error } = useCaixinhasCatalog()
 
   const data = useMemo(() => filterCaixinhasByQuery(catalog, query), [catalog, query])
@@ -57,81 +53,63 @@ export default function Home() {
     <Layout>
       <Box
         component="main"
-        sx={{
-          flexGrow: 1,
-          minHeight: '100vh',
-          py: { xs: 4, md: 8 },
-          background: theme.palette.mode === 'dark' ? 'neutral.800' : 'neutral.50',
-          display: 'flex',
-          alignItems: 'flex-start',
-          justifyContent: 'center',
-        }}
+        sx={{ flexGrow: 1, minHeight: '100vh', py: { xs: 5, md: 8 } }}
       >
         <Container maxWidth="lg">
-          <Stack spacing={4} alignItems="center">
-            <Typography variant="h3" fontWeight={700} align="center" gutterBottom>
-              Caixinhas disponíveis
+          {/* Header */}
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ letterSpacing: '0.5px', lineHeight: 2 }}
+          >
+            Comunidade
+          </Typography>
+          <Typography
+            variant="h4"
+            fontWeight={700}
+            sx={{ mt: 0.5, mb: 3 }}
+          >
+            Caixinhas disponíveis
+          </Typography>
+
+          {/* Search */}
+          <Box sx={{ maxWidth: 560, mb: 4 }}>
+            <CaixinhaSearch search={search} />
+          </Box>
+
+          {/* Grid de cards */}
+          {paged.length === 0 ? (
+            <Typography align="center" color="text.secondary" sx={{ py: 6 }}>
+              Nenhuma caixinha encontrada.
             </Typography>
-            <Paper elevation={3} sx={{ 
-              width: '100%', 
-              maxWidth: 600, 
-              p: 2, 
-              mb: 2, 
-              borderRadius: 3,
-              background: theme.palette.mode === 'dark' ? 'neutral.800' : 'neutral.50',
-            }}>
-              <CaixinhaSearch search={search} />
-            </Paper>
-            <Paper elevation={1} sx={{ 
-              width: '100%', 
-              p: { xs: 1, sm: 3 }, 
-              borderRadius: 3, 
-            }}>
-              <Grid
-                container
-                spacing={{ xs: 3, lg: 4 }}
-                justifyContent="center"
-              >
-                {paged.length === 0 ? (
-                  <Grid xs={12}>
-                    <Typography align="center" color="text.secondary">
-                      Nenhuma caixinha encontrada.
-                    </Typography>
-                  </Grid>
-                ) : (
-                  paged.map((caixinha: Caixinha, index: number) => (
-                    <Grid
-                      key={caixinha.id || index}
-                      xs={12}
-                      sm={6}
-                      md={4}
-                    >
-                      <CaixinhaCard key={caixinha.id} caixinha={caixinha} />
-                    </Grid>
-                  ))
-                )}
-              </Grid>
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  mt: 4
-                }}
-              >
-                <Pagination
-                  count={pageCount}
-                  page={page}
-                  onChange={(_, value) => setPage(value)}
-                  size="medium"
-                  color="primary"
-                  shape="rounded"
-                />
-              </Box>
-            </Paper>
-          </Stack>
+          ) : (
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+                gap: 3,
+              }}
+            >
+              {paged.map((caixinha: Caixinha, index: number) => (
+                <CaixinhaCard key={caixinha.id || index} caixinha={caixinha} />
+              ))}
+            </Box>
+          )}
+
+          {/* Paginação */}
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 5 }}>
+            <Pagination
+              count={pageCount}
+              page={page}
+              onChange={(_, value) => setPage(value)}
+              size="medium"
+              color="primary"
+              shape="rounded"
+            />
+          </Box>
         </Container>
       </Box>
-      <Footer/>
+      <Footer />
     </Layout>
   )
 }

--- a/front-caixinha/src/pages/deposito/index.tsx
+++ b/front-caixinha/src/pages/deposito/index.tsx
@@ -3,22 +3,24 @@ import {
     Box,
     Button,
     Card,
-    CardContent,
     Chip,
+    CircularProgress,
+    Collapse,
     Container,
+    Divider,
     FormControl,
     FormLabel,
-    Unstable_Grid2 as Grid,
-    Link,
     OutlinedInput,
     Stack,
-    SvgIcon,
     Typography,
-    useTheme,
-    CircularProgress,
 } from "@mui/material"
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CheckIcon from '@mui/icons-material/Check';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
+import CreditCardIcon from '@mui/icons-material/CreditCard';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
+import BoltIcon from '@mui/icons-material/Bolt';
 import { FormEvent, Key, useCallback, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { doDeposito, getBuckets, getChavesPix, uploadResource } from '../api/api.service'
@@ -28,19 +30,29 @@ import CenteredCircularProgress from '@/components/CenteredCircularProgress';
 import toast from 'react-hot-toast';
 import { Seo } from '@/components/Seo';
 import { useUserAuth } from "@/hooks/useUserAuth";
-import { ArrowBackIos, Mail, QrCode2 } from "@mui/icons-material";
+
+const METODOS = [
+    { id: 'pix', icon: <QrCode2Icon />, label: 'Pix', desc: 'Aprovação na hora' },
+    { id: 'cartao', icon: <CreditCardIcon />, label: 'Cartão', desc: 'Crédito ou débito' },
+    { id: 'boleto', icon: <ReceiptLongIcon />, label: 'Boleto', desc: 'Até 1 dia útil' },
+]
+
+const QUICKS = [50, 100, 200, 500]
+
+const brl = (n: number) =>
+    'R$ ' + n.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 
 export default function Deposito() {
     const { user } = useUserAuth()
     const { caixinha } = useCaixinhaSelect()
     const router = useRouter()
-    const theme = useTheme()
     const [isLoading, setLoading] = useState(false)
     const [uploadingName, setUploadingName] = useState<string | null>(null)
     const [arquivos, setArquivo] = useState<any>([])
     const [pix, setPix] = useState<any>(null)
+    const [metodo, setMetodo] = useState('pix')
     const [solicitacao, setSolicitacao] = useState({
-        valor: 0,
+        valor: 200,
         fileUrl: '',
         memberName: "",
         email: '',
@@ -158,196 +170,261 @@ export default function Deposito() {
     return (
         <Layout>
             <Seo title="Deposito" />
-            <Box
-                component="main"
-                sx={{
-                    flexGrow: 1,
-                    py: 8,
-                    background: theme.palette.mode === 'dark' ? 'neutral.800' : 'neutral.50',
-                }}
-            >
-                <Container maxWidth="lg">
-                    <Stack spacing={3}>
-                        <Link
-                            color="text.primary"
-                            component="a"
-                            href={'/'}
-                            sx={{
-                                alignItems: 'center',
-                                display: 'inline-flex',
-                                width: 'fit-content'
-                            }}
-                            underline="hover"
+            <Box component="main" sx={{ flexGrow: 1, py: 8 }}>
+                <Container maxWidth="md">
+                    <Box sx={{ mb: 3 }}>
+                        <Typography
+                            variant="overline"
+                            color="text.secondary"
+                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', lineHeight: 2 }}
                         >
-                            <SvgIcon sx={{ mr: 1 }}>
-                                <ArrowBackIos />
-                            </SvgIcon>
-                            <Typography variant="subtitle2">
-                                Voltar para Home
-                            </Typography>
-                        </Link>
-
-                        <Typography variant="h4" fontWeight={700} gutterBottom>
-                            Depositando em {caixinha?.name}
+                            Minha caixinha
                         </Typography>
+                        <Typography variant="h4" fontWeight={700} sx={{ mt: 0.5 }}>
+                            Novo depósito {caixinha?.name ? `em ${caixinha.name}` : ''}
+                        </Typography>
+                    </Box>
 
-                        <Grid container spacing={3}>
-                            <Grid xs={12} md={6}>
-                                <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
-                                    <CardContent>
-                                        <Stack spacing={3}>
-                                            <Stack direction="row" alignItems="center" spacing={2}>
-                                                <Avatar sx={{ bgcolor: 'primary.main' }}>
-                                                    <QrCode2 />
-                                                </Avatar>
-                                                <Typography variant="h6">
-                                                    Depósito via PIX
-                                                </Typography>
-                                            </Stack>
+                    <form onSubmit={request}>
+                        <Box
+                            sx={{
+                                display: 'grid',
+                                gridTemplateColumns: { xs: '1fr', md: '1.3fr 1fr' },
+                                gap: 3,
+                                alignItems: 'start',
+                            }}
+                        >
+                            {/* Card esquerdo — formulário */}
+                            <Card sx={{ p: 3, borderRadius: 5, boxShadow: '0 5px 22px rgba(0,0,0,0.08)' }}>
+                                <Stack spacing={3}>
+                                    {/* Valor */}
+                                    <Box>
+                                        <Typography
+                                            variant="overline"
+                                            color="text.secondary"
+                                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px' }}
+                                        >
+                                            Valor do depósito
+                                        </Typography>
+                                        <Box
+                                            sx={{
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: 1,
+                                                border: '2px solid',
+                                                borderColor: 'primary.main',
+                                                borderRadius: 2,
+                                                px: 2,
+                                                py: 1.5,
+                                                mt: 1,
+                                                boxShadow: (t) => `0 0 0 3px ${t.palette.primary.main}18`,
+                                            }}
+                                        >
+                                            <Typography variant="h5" fontWeight={700} color="text.secondary">
+                                                R$
+                                            </Typography>
+                                            <OutlinedInput
+                                                required
+                                                name='valor'
+                                                type='number'
+                                                value={solicitacao.valor}
+                                                onChange={handleChange}
+                                                sx={{
+                                                    border: 'none',
+                                                    '& fieldset': { border: 'none' },
+                                                    '& input': { fontSize: 28, fontWeight: 700, p: 0 },
+                                                    flex: 1,
+                                                }}
+                                            />
+                                        </Box>
+                                        {/* Valores rápidos */}
+                                        <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+                                            {QUICKS.map((q) => (
+                                                <Button
+                                                    key={q}
+                                                    size="small"
+                                                    variant={solicitacao.valor === q ? 'contained' : 'outlined'}
+                                                    onClick={() => setSolicitacao((prev) => ({ ...prev, valor: q }))}
+                                                    sx={{ flex: 1, borderRadius: 2.5, fontWeight: 600 }}
+                                                >
+                                                    +{q}
+                                                </Button>
+                                            ))}
+                                        </Stack>
+                                    </Box>
 
-                                            <Box sx={{ 
-                                                display: 'flex', 
-                                                justifyContent: 'center',
-                                                bgcolor: 'background.paper',
-                                                p: 2,
-                                                borderRadius: 2
-                                            }}>
+                                    {/* Método de pagamento */}
+                                    <Box>
+                                        <Typography
+                                            variant="overline"
+                                            color="text.secondary"
+                                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px' }}
+                                        >
+                                            Forma de pagamento
+                                        </Typography>
+                                        <Stack spacing={1} sx={{ mt: 1 }}>
+                                            {METODOS.map((m) => {
+                                                const ativo = metodo === m.id
+                                                return (
+                                                    <Box
+                                                        key={m.id}
+                                                        onClick={() => setMetodo(m.id)}
+                                                        sx={{
+                                                            display: 'flex',
+                                                            alignItems: 'center',
+                                                            gap: 1.5,
+                                                            p: 1.5,
+                                                            borderRadius: 3,
+                                                            cursor: 'pointer',
+                                                            border: '1px solid',
+                                                            borderColor: ativo ? 'primary.main' : 'divider',
+                                                            bgcolor: ativo ? 'primary.lightest' : 'background.paper',
+                                                            transition: 'all 0.15s',
+                                                        }}
+                                                    >
+                                                        <Avatar
+                                                            sx={{
+                                                                width: 40,
+                                                                height: 40,
+                                                                bgcolor: ativo ? 'primary.main' : 'neutral.100',
+                                                                color: ativo ? '#fff' : 'text.secondary',
+                                                            }}
+                                                        >
+                                                            {m.icon}
+                                                        </Avatar>
+                                                        <Box sx={{ flex: 1 }}>
+                                                            <Typography variant="body2" fontWeight={600}>{m.label}</Typography>
+                                                            <Typography variant="caption" color="text.secondary">{m.desc}</Typography>
+                                                        </Box>
+                                                        <Box
+                                                            sx={{
+                                                                width: 20, height: 20, borderRadius: '50%',
+                                                                border: '2px solid', borderColor: ativo ? 'primary.main' : 'divider',
+                                                                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                                            }}
+                                                        >
+                                                            {ativo && (
+                                                                <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: 'primary.main' }} />
+                                                            )}
+                                                        </Box>
+                                                    </Box>
+                                                )
+                                            })}
+                                        </Stack>
+
+                                        {/* QR Code PIX — expande quando Pix está selecionado */}
+                                        <Collapse in={metodo === 'pix'}>
+                                            <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
                                                 <Avatar
                                                     src={pix?.url}
                                                     variant="square"
-                                                    sx={{
-                                                        height: 300,
-                                                        width: 300,
-                                                        boxShadow: 2
-                                                    }}
+                                                    sx={{ height: 200, width: 200, borderRadius: 2, boxShadow: 2 }}
                                                 />
+                                                {pix?.chave && (
+                                                    <Typography variant="caption" color="text.secondary" align="center">
+                                                        Chave PIX: {pix.chave}
+                                                    </Typography>
+                                                )}
                                             </Box>
+                                        </Collapse>
+                                    </Box>
 
-                                            <Typography variant="subtitle1" align="center" color="text.secondary">
-                                                Chave PIX: {pix?.chave}
-                                            </Typography>
+                                    {/* Comprovante */}
+                                    <Box>
+                                        <FormLabel sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', textTransform: 'uppercase', color: 'text.secondary' }}>
+                                            Comprovante de pagamento
+                                        </FormLabel>
+                                        <Box sx={{ mt: 1, mb: 1 }}>
+                                            {arquivos.map((item: { name: string, index: Key }) =>
+                                                getChipByItem(item)
+                                            )}
+                                        </Box>
+                                        <Button
+                                            onClick={addComprovante}
+                                            variant="outlined"
+                                            size="small"
+                                            startIcon={<CloudUploadIcon />}
+                                            sx={{ borderRadius: 2 }}
+                                        >
+                                            Adicionar comprovante
+                                        </Button>
+                                    </Box>
+                                </Stack>
+                            </Card>
 
-                                            <Stack direction="row" alignItems="center" spacing={2} sx={{ mt: 2 }}>
-                                                <Avatar sx={{ bgcolor: 'primary.main' }}>
-                                                    <Mail />
-                                                </Avatar>
-                                                <Typography variant="body2" color="text.secondary">
-                                                    Em caso de dúvidas, entre em contato com os administradores da caixinha
-                                                </Typography>
-                                            </Stack>
-                                        </Stack>
-                                    </CardContent>
-                                </Card>
-                            </Grid>
+                            {/* Card direito — resumo */}
+                            <Card sx={{ p: 3, borderRadius: 5, boxShadow: '0 5px 22px rgba(0,0,0,0.08)', position: { md: 'sticky' }, top: { md: 88 } }}>
+                                <Typography variant="h6" fontWeight={700} sx={{ mb: 2 }}>
+                                    Resumo
+                                </Typography>
+                                <Stack spacing={0}>
+                                    {[
+                                        ['Caixinha', caixinha?.name ?? '—'],
+                                        ['Valor', brl(solicitacao.valor || 0)],
+                                        ['Taxa', 'Grátis'],
+                                    ].map(([label, value]) => (
+                                        <Box
+                                            key={label}
+                                            sx={{ display: 'flex', justifyContent: 'space-between', py: 1.25 }}
+                                        >
+                                            <Typography variant="body2" color="text.secondary">{label}</Typography>
+                                            <Typography variant="body2" fontWeight={600} align="right">{value}</Typography>
+                                        </Box>
+                                    ))}
+                                    <Divider sx={{ my: 1 }} />
+                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', py: 1 }}>
+                                        <Typography fontWeight={700}>Total</Typography>
+                                        <Typography variant="h5" fontWeight={700} color="primary">{brl(solicitacao.valor || 0)}</Typography>
+                                    </Box>
+                                </Stack>
 
-                            <Grid xs={12} md={6}>
-                                <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
-                                    <CardContent>
-                                        <form onSubmit={request}>
-                                            <Stack spacing={3}>
-                                                <Typography variant="h6" gutterBottom>
-                                                    Informações do Depósito
-                                                </Typography>
+                                {/* Badge de proteção */}
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 1,
+                                        bgcolor: 'success.lightest',
+                                        borderRadius: 2.5,
+                                        px: 1.5,
+                                        py: 1.25,
+                                        my: 2,
+                                    }}
+                                >
+                                    <VerifiedUserIcon sx={{ fontSize: 18, color: 'success.dark' }} />
+                                    <Typography variant="caption" color="success.dark" fontWeight={500}>
+                                        Transação protegida e registrada na caixinha.
+                                    </Typography>
+                                </Box>
 
-                                                <Grid container spacing={2}>
-                                                    <Grid xs={12} sm={6}>
-                                                        <FormControl fullWidth>
-                                                            <FormLabel>Nome</FormLabel>
-                                                            <OutlinedInput
-                                                                required
-                                                                name="memberName"
-                                                                disabled
-                                                                value={solicitacao.memberName}
-                                                                defaultValue={solicitacao.memberName}
-                                                                onChange={handleChange}
-                                                            />
-                                                        </FormControl>
-                                                    </Grid>
-                                                    <Grid xs={12} sm={6}>
-                                                        <FormControl fullWidth>
-                                                            <FormLabel>Email</FormLabel>
-                                                            <OutlinedInput
-                                                                required
-                                                                name="email"
-                                                                type='email'
-                                                                disabled
-                                                                value={solicitacao.email}
-                                                                defaultValue={solicitacao.email}
-                                                                onChange={handleChange}
-                                                            />
-                                                        </FormControl>
-                                                    </Grid>
-                                                </Grid>
+                                <FormControl fullWidth sx={{ mb: 2 }}>
+                                    <FormLabel sx={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.5px', textTransform: 'uppercase', color: 'text.secondary', mb: 0.5 }}>
+                                        Nome
+                                    </FormLabel>
+                                    <OutlinedInput
+                                        required
+                                        name="memberName"
+                                        disabled
+                                        size="small"
+                                        value={solicitacao.memberName}
+                                        onChange={handleChange}
+                                        sx={{ borderRadius: 2 }}
+                                    />
+                                </FormControl>
 
-                                                <FormControl fullWidth>
-                                                    <FormLabel>Valor do Depósito *</FormLabel>
-                                                    <OutlinedInput
-                                                        required
-                                                        name='valor'
-                                                        type='number'
-                                                        value={solicitacao.valor}
-                                                        onChange={handleChange}
-                                                        startAdornment={<Typography sx={{ mr: 1 }}>R$</Typography>}
-                                                    />
-                                                </FormControl>
-
-                                                <Box>
-                                                    <FormLabel>Comprovante de Pagamento</FormLabel>
-                                                    <Box sx={{ mt: 1, mb: 2 }}>
-                                                        {arquivos.map((item: { name: string, index: Key }) =>
-                                                            getChipByItem(item)
-                                                        )}
-                                                    </Box>
-                                                    <Button
-                                                        onClick={addComprovante}
-                                                        variant="outlined"
-                                                        startIcon={<CloudUploadIcon />}
-                                                    >
-                                                        Adicionar Comprovante
-                                                    </Button>
-                                                </Box>
-
-                                                <FormControl fullWidth>
-                                                    <FormLabel>Mensagem (opcional)</FormLabel>
-                                                    <OutlinedInput
-                                                        fullWidth
-                                                        name="message"
-                                                        multiline
-                                                        rows={4}
-                                                    />
-                                                </FormControl>
-
-                                                <Button
-                                                    fullWidth
-                                                    size="large"
-                                                    variant="contained"
-                                                    type="submit"
-                                                    sx={{ mt: 2 }}
-                                                >
-                                                    Confirmar Depósito
-                                                </Button>
-
-                                                <Typography
-                                                    color="text.secondary"
-                                                    variant="body2"
-                                                    align="center"
-                                                >
-                                                    Ao confirmar, você concorda com nossa{' '}
-                                                    <Link
-                                                        color="primary"
-                                                        href="#"
-                                                        underline="hover"
-                                                    >
-                                                        Política de Privacidade
-                                                    </Link>
-                                                </Typography>
-                                            </Stack>
-                                        </form>
-                                    </CardContent>
-                                </Card>
-                            </Grid>
-                        </Grid>
-                    </Stack>
+                                <Button
+                                    fullWidth
+                                    size="large"
+                                    variant="contained"
+                                    type="submit"
+                                    startIcon={<BoltIcon />}
+                                    sx={{ borderRadius: 3 }}
+                                >
+                                    Depositar {brl(solicitacao.valor || 0)}
+                                </Button>
+                            </Card>
+                        </Box>
+                    </form>
                 </Container>
             </Box>
         </Layout>

--- a/front-caixinha/src/pages/emprestimo/index.tsx
+++ b/front-caixinha/src/pages/emprestimo/index.tsx
@@ -2,18 +2,18 @@ import {
     Box,
     Button,
     Card,
-    CardContent,
+    CircularProgress,
     Container,
+    Divider,
     FormControl,
     FormLabel,
-    InputAdornment,
-    Link,
+    List,
+    ListItem,
+    ListItemText,
     OutlinedInput,
+    Slider,
     Stack,
-    SvgIcon,
     Typography,
-    Unstable_Grid2 as Grid,
-    useTheme
 } from "@mui/material"
 import { FormEvent, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
@@ -23,21 +23,24 @@ import { useCaixinhaSelect } from '@/hooks/useCaixinhaSelect'
 import CenteredCircularProgress from '@/components/CenteredCircularProgress'
 import toast from 'react-hot-toast'
 import { Seo } from '@/components/Seo'
-import { ArrowBackIos, CreditCard, Percent, AttachMoney } from '@mui/icons-material'
-import { EmprestimoResumo } from '@/components/emprestimos/emprestimo-resumo'
 import { useUserAuth } from "@/hooks/useUserAuth";
+
+const PARCELAS = [2, 3, 6, 12]
+const TAXA = 0.018
+
+const brl = (n: number) =>
+    'R$ ' + n.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 
 const Emprestimo = () => {
     const { user } = useUserAuth()
     const router = useRouter()
     const { caixinha } = useCaixinhaSelect()
-    const theme = useTheme()
     const [isLoading, setLoading] = useState(false)
     const [motivoTemp, setMotivoTemp] = useState('')
     const [solicitacao, setSolicitacao] = useState({
-        valor: 0,
+        valor: 500,
         juros: 2,
-        parcela: 0,
+        parcela: 3,
         name: "",
         email: '',
         fees: 3.00
@@ -56,38 +59,12 @@ const Emprestimo = () => {
     }, [user])
 
     useEffect(() => {
-        if (!solicitacao.parcela) {
-            return
-        }
-        setStateParcelas({
-            data: [],
-            loading: true
-        })
-
+        if (!solicitacao.parcela) return
+        setStateParcelas({ data: [], loading: true })
         getValorParcelas({ parcelas: solicitacao.parcela, total: solicitacao.valor })
-            .then(response => {
-                setStateParcelas({
-                    data: response,
-                    loading: false
-                })
-            }).catch(() => {
-                setStateParcelas({
-                    data: [],
-                    loading: false
-                })
-            })
-
-    }, [solicitacao])
-
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        if (name === 'motivo') {
-            setMotivoTemp(value)
-            return
-        }
-
-        setSolicitacao({ ...solicitacao, [name]: value });
-    }
+            .then(response => setStateParcelas({ data: response, loading: false }))
+            .catch(() => setStateParcelas({ data: [], loading: false }))
+    }, [solicitacao.valor, solicitacao.parcela])
 
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
@@ -104,170 +81,201 @@ const Emprestimo = () => {
             })
     }
 
+    // mesma fórmula do EmprestimoResumo original
+    const total = solicitacao.valor + (solicitacao.valor * (solicitacao.juros / 100)) + solicitacao.fees
+    const parcelaValor = total / solicitacao.parcela
+
     if (isLoading) return <CenteredCircularProgress />
 
     return (
         <>
             <Seo title="Emprestimo" />
-            <Box
-                component="main"
-                sx={{
-                    flexGrow: 1,
-                    py: 8,
-                    background: theme.palette.mode === 'dark' ? 'neutral.800' : 'neutral.50',
-                }}
-            >
-                <Container maxWidth="lg">
-                    <Stack spacing={3}>
-                        <Link
-                            color="text.primary"
-                            component="a"
-                            href={'/'}
-                            sx={{
-                                alignItems: 'center',
-                                display: 'inline-flex',
-                                width: 'fit-content'
-                            }}
-                            underline="hover"
+            <Box component="main" sx={{ flexGrow: 1, py: 8 }}>
+                <Container maxWidth="md">
+                    <Box sx={{ mb: 3 }}>
+                        <Typography
+                            variant="overline"
+                            color="text.secondary"
+                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', lineHeight: 2 }}
                         >
-                            <SvgIcon sx={{ mr: 1 }}>
-                                <ArrowBackIos />
-                            </SvgIcon>
-                            <Typography variant="subtitle2">
-                                Voltar para Home
-                            </Typography>
-                        </Link>
-
-                        <Typography variant="h4" fontWeight={700} gutterBottom>
-                            Novo empréstimo na {caixinha?.name}
+                            Empréstimo coletivo
                         </Typography>
+                        <Typography variant="h4" fontWeight={700} sx={{ mt: 0.5 }}>
+                            Novo empréstimo {caixinha?.name ? `na ${caixinha.name}` : ''}
+                        </Typography>
+                    </Box>
 
-                        <Grid container spacing={3}>
-                            <Grid xs={12} md={6}>
-                                <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
-                                    <CardContent>
-                                        <Stack spacing={3}>
-                                            <Typography variant="h6" gutterBottom>
-                                                Resumo do Empréstimo
-                                            </Typography>
-                                            <EmprestimoResumo
-                                                solicitacao={solicitacao}
-                                                stateParcelas={stateParcelas}
-                                            />
-                                        </Stack>
-                                    </CardContent>
-                                </Card>
-                            </Grid>
+                    <form onSubmit={handleSubmit}>
+                        <Box
+                            sx={{
+                                display: 'grid',
+                                gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                                gap: 3,
+                                alignItems: 'start',
+                            }}
+                        >
+                            {/* Card esquerdo — formulário visual */}
+                            <Card sx={{ p: 3, borderRadius: 5, boxShadow: '0 5px 22px rgba(0,0,0,0.08)' }}>
+                                <Stack spacing={3}>
+                                    {/* Valor com slider */}
+                                    <Box>
+                                        <Typography
+                                            variant="overline"
+                                            color="text.secondary"
+                                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px' }}
+                                        >
+                                            Valor solicitado
+                                        </Typography>
+                                        <Typography
+                                            variant="h4"
+                                            color="primary"
+                                            fontWeight={700}
+                                            sx={{ mt: 0.5 }}
+                                        >
+                                            {brl(solicitacao.valor)}
+                                        </Typography>
+                                        <Slider
+                                            min={100}
+                                            max={5000}
+                                            step={100}
+                                            value={solicitacao.valor}
+                                            onChange={(_, v) =>
+                                                setSolicitacao((prev) => ({ ...prev, valor: v as number }))
+                                            }
+                                            sx={{ mt: 1.5, color: 'primary.main' }}
+                                        />
+                                    </Box>
 
-                            <Grid xs={12} md={6}>
-                                <Card sx={{ height: '100%', boxShadow: 3, borderRadius: 2 }}>
-                                    <CardContent>
-                                        <form onSubmit={handleSubmit}>
-                                            <Stack spacing={3}>
-                                                <Typography variant="h6" gutterBottom>
-                                                    Informações do Empréstimo
-                                                </Typography>
-
-                                                <Grid container spacing={2}>
-                                                    <Grid xs={12}>
-                                                        <FormControl fullWidth>
-                                                            <FormLabel>Valor Solicitado</FormLabel>
-                                                            <OutlinedInput
-                                                                required
-                                                                name='valor'
-                                                                type='number'
-                                                                value={solicitacao.valor}
-                                                                onChange={handleChange}
-                                                                startAdornment={
-                                                                    <InputAdornment position="start">
-                                                                        <AttachMoney />
-                                                                    </InputAdornment>
-                                                                }
-                                                            />
-                                                        </FormControl>
-                                                    </Grid>
-
-                                                    <Grid xs={12} sm={6}>
-                                                        <FormControl fullWidth>
-                                                            <FormLabel>Juros (%)</FormLabel>
-                                                            <OutlinedInput
-                                                                required
-                                                                name='juros'
-                                                                type='number'
-                                                                value={solicitacao.juros}
-                                                                onChange={handleChange}
-                                                                startAdornment={
-                                                                    <InputAdornment position="start">
-                                                                        <Percent />
-                                                                    </InputAdornment>
-                                                                }
-                                                            />
-                                                        </FormControl>
-                                                    </Grid>
-
-                                                    <Grid xs={12} sm={6}>
-                                                        <FormControl fullWidth>
-                                                            <FormLabel>Quantidade de Parcelas</FormLabel>
-                                                            <OutlinedInput
-                                                                required
-                                                                name='parcela'
-                                                                type='number'
-                                                                value={solicitacao.parcela}
-                                                                onChange={handleChange}
-                                                                startAdornment={
-                                                                    <InputAdornment position="start">
-                                                                        <CreditCard />
-                                                                    </InputAdornment>
-                                                                }
-                                                            />
-                                                        </FormControl>
-                                                    </Grid>
-                                                </Grid>
-
-                                                <FormControl fullWidth>
-                                                    <FormLabel>Motivo do Empréstimo</FormLabel>
-                                                    <OutlinedInput
-                                                        fullWidth
-                                                        name="motivo"
-                                                        value={motivoTemp}
-                                                        onChange={handleChange}
-                                                        multiline
-                                                        rows={4}
-                                                        placeholder="Descreva o motivo do seu empréstimo..."
-                                                    />
-                                                </FormControl>
-
+                                    {/* Parcelas */}
+                                    <Box>
+                                        <Typography
+                                            variant="overline"
+                                            color="text.secondary"
+                                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px' }}
+                                        >
+                                            Parcelamento
+                                        </Typography>
+                                        <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                                            {PARCELAS.map((m) => (
                                                 <Button
-                                                    fullWidth
-                                                    size="large"
-                                                    variant="contained"
-                                                    type="submit"
-                                                    sx={{ mt: 2 }}
+                                                    key={m}
+                                                    variant={solicitacao.parcela === m ? 'contained' : 'outlined'}
+                                                    size="small"
+                                                    onClick={() =>
+                                                        setSolicitacao((prev) => ({ ...prev, parcela: m }))
+                                                    }
+                                                    sx={{ flex: 1, borderRadius: 2.5, fontWeight: 600 }}
                                                 >
-                                                    Solicitar Empréstimo
+                                                    {m}x
                                                 </Button>
+                                            ))}
+                                        </Stack>
+                                    </Box>
 
-                                                <Typography
-                                                    color="text.secondary"
-                                                    variant="body2"
-                                                    align="center"
-                                                >
-                                                    Ao solicitar, você concorda com nossa{' '}
-                                                    <Link
-                                                        color="primary"
-                                                        href="#"
-                                                        underline="hover"
-                                                    >
-                                                        Política de Privacidade
-                                                    </Link>
+                                    {/* Motivo */}
+                                    <FormControl fullWidth>
+                                        <FormLabel sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', textTransform: 'uppercase', color: 'text.secondary', mb: 0.75 }}>
+                                            Motivo do empréstimo
+                                        </FormLabel>
+                                        <OutlinedInput
+                                            name="motivo"
+                                            value={motivoTemp}
+                                            onChange={(e) => setMotivoTemp(e.target.value)}
+                                            multiline
+                                            rows={3}
+                                            placeholder="Descreva o motivo..."
+                                            sx={{ borderRadius: 2 }}
+                                        />
+                                    </FormControl>
+
+                                    {/* Juros (obrigatório para o backend, exibido como campo secundário) */}
+                                    <FormControl>
+                                        <FormLabel sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', textTransform: 'uppercase', color: 'text.secondary', mb: 0.75 }}>
+                                            Taxa de juros (%)
+                                        </FormLabel>
+                                        <OutlinedInput
+                                            required
+                                            name='juros'
+                                            type='number'
+                                            size="small"
+                                            value={solicitacao.juros}
+                                            onChange={(e) =>
+                                                setSolicitacao((prev) => ({ ...prev, juros: Number(e.target.value) }))
+                                            }
+                                            sx={{ borderRadius: 2, maxWidth: 120 }}
+                                        />
+                                    </FormControl>
+                                </Stack>
+                            </Card>
+
+                            {/* Card direito — resumo */}
+                            <Card sx={{ p: 3, borderRadius: 5, boxShadow: '0 5px 22px rgba(0,0,0,0.08)', position: { md: 'sticky' }, top: { md: 88 } }}>
+                                <Typography variant="h6" fontWeight={700} sx={{ mb: 2 }}>
+                                    Resumo
+                                </Typography>
+
+                                {/* Valores */}
+                                <Stack spacing={0}>
+                                    {[
+                                        ['Subtotal', brl(solicitacao.valor)],
+                                        ['Taxas', `${solicitacao.juros}%`],
+                                        ['Impostos', `R$ ${solicitacao.fees.toFixed(2)}`],
+                                    ].map(([label, value]) => (
+                                        <Box
+                                            key={label}
+                                            sx={{ display: 'flex', justifyContent: 'space-between', py: 1 }}
+                                        >
+                                            <Typography variant="body2" color="text.secondary">{label}</Typography>
+                                            <Typography variant="body2" fontWeight={600}>{value}</Typography>
+                                        </Box>
+                                    ))}
+                                    <Divider sx={{ my: 1 }} />
+                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', py: 1 }}>
+                                        <Typography fontWeight={700}>Total</Typography>
+                                        <Typography variant="h5" fontWeight={700} color="primary">{brl(total)}</Typography>
+                                    </Box>
+                                    {!stateParcelas.loading && stateParcelas.data.length === 0 && solicitacao.parcela > 0 && (
+                                        <Typography variant="caption" color="text.secondary">
+                                            {solicitacao.parcela}× de {brl(parcelaValor)}
+                                        </Typography>
+                                    )}
+                                </Stack>
+
+                                {/* Parcelas do backend */}
+                                {stateParcelas.loading && (
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, my: 1 }}>
+                                        <CircularProgress size={14} />
+                                        <Typography variant="caption" color="text.secondary">Calculando parcelamento…</Typography>
+                                    </Box>
+                                )}
+                                {stateParcelas.data.length > 0 && (
+                                    <List disablePadding dense sx={{ mt: 1 }}>
+                                        {stateParcelas.data.map((parcela: any, index: number) => (
+                                            <ListItem key={index} sx={{ py: 0.5, px: 0 }}>
+                                                <ListItemText
+                                                    primary={`Parcela ${index + 1}`}
+                                                    primaryTypographyProps={{ variant: 'body2', color: 'text.secondary' }}
+                                                />
+                                                <Typography variant="body2" fontWeight={600}>
+                                                    R$ {parcela.value}
                                                 </Typography>
-                                            </Stack>
-                                        </form>
-                                    </CardContent>
-                                </Card>
-                            </Grid>
-                        </Grid>
-                    </Stack>
+                                            </ListItem>
+                                        ))}
+                                    </List>
+                                )}
+
+                                <Button
+                                    fullWidth
+                                    size="large"
+                                    variant="contained"
+                                    type="submit"
+                                    sx={{ mt: 2, borderRadius: 3 }}
+                                >
+                                    Solicitar empréstimo
+                                </Button>
+                            </Card>
+                        </Box>
+                    </form>
                 </Container>
             </Box>
         </>

--- a/front-caixinha/src/pages/extrato/index.tsx
+++ b/front-caixinha/src/pages/extrato/index.tsx
@@ -1,6 +1,7 @@
 import Layout from "@/components/Layout";
 import { Scrollbar } from "@/components/scrollbar";
 import {
+    Avatar,
     Box,
     Container,
     Stack,
@@ -20,6 +21,8 @@ import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import FilterAltOffIcon from '@mui/icons-material/FilterAltOff';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import DisplayValorMonetario from "@/components/display-valor-monetario";
 import { useTranslation } from "react-i18next";
 import { useExtrato } from "@/features/caixinha/hooks/useExtrato";
@@ -66,74 +69,93 @@ export default function Extrato() {
         }
     }, [error, router])
 
+    const isDeposito = (tipo: string) =>
+        tipo?.toUpperCase().includes('DEPOSITO') || tipo?.toUpperCase().includes('DEPÓSITO')
+
+    const statusColor = (s: string): 'warning' | 'success' | 'primary' | 'default' => {
+        const lower = s?.toLowerCase()
+        if (lower === 'pending' || lower === 'pendente') return 'warning'
+        if (lower === 'completed' || lower === 'concluido' || lower === 'concluído') return 'success'
+        if (lower === 'quitado') return 'primary'
+        return 'default'
+    }
+
+    const statusLabel = (s: string) => {
+        const lower = s?.toLowerCase()
+        if (lower === 'completed') return 'Concluído'
+        if (lower === 'pending') return 'Pendente'
+        return s
+    }
+
+    const headerSx = {
+        fontSize: 12,
+        fontWeight: 600,
+        letterSpacing: '0.5px',
+        textTransform: 'uppercase' as const,
+        color: 'text.secondary',
+    }
+
     return (
         <Layout>
-            <Box
-                component="main"
-                sx={{
-                    flexGrow: 1,
-                    py: 8
-                }}
-            >
+            <Box component="main" sx={{ flexGrow: 1, py: 8 }}>
                 <Container maxWidth="xl">
                     <Stack spacing={3}>
-                        <Stack
-                            direction="row"
-                            justifyContent="space-between"
-                            spacing={4}
-                        >
-                            <Stack spacing={1}>
-                                <Typography variant="h4">
-                                    {t('extrato')}
-                                </Typography>
+                        {/* Header */}
+                        <Box>
+                            <Typography
+                                variant="overline"
+                                color="text.secondary"
+                                sx={{ letterSpacing: '0.5px', lineHeight: 2 }}
+                            >
+                                {t('extrato_filtros.movimentacoes') || 'Movimentações'}
+                            </Typography>
+                            <Typography variant="h4" fontWeight={700}>
+                                {t('extrato')}
+                            </Typography>
+                        </Box>
 
-                            </Stack>
-
-                        </Stack>
-                        <Card sx={{ p: 2, width: '100%' }}>
-                            <Typography> {t('filtros')}</Typography>
+                        {/* Filtros */}
+                        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
                             <Chip
+                                size="small"
                                 label={somenteMeuFiltro ? t('extrato_filtros.todo_mundo') : t('extrato_filtros.somente_meu')}
                                 variant={somenteMeuFiltro ? 'filled' : 'outlined'}
                                 color={somenteMeuFiltro ? 'success' : 'default'}
                                 onClick={() => { patchQuery({ meu: somenteMeuFiltro ? '0' : '1' }) }}
-                                onDelete={() => { patchQuery({ emp: emprestimosFiltro ? '0' : '1' }) }}
-                                deleteIcon={somenteMeuFiltro ? <FilterAltOffIcon /> : <FilterAltIcon />} />
+                                onDelete={() => { patchQuery({ meu: somenteMeuFiltro ? '0' : '1' }) }}
+                                deleteIcon={somenteMeuFiltro ? <FilterAltOffIcon fontSize="small" /> : <FilterAltIcon fontSize="small" />}
+                            />
                             <Chip
+                                size="small"
                                 label={depositosFiltro ? t('extrato_filtros.remover_depositos') : t('extrato_filtros.incluir_depositos')}
                                 variant={depositosFiltro ? 'filled' : 'outlined'}
                                 color={depositosFiltro ? 'success' : 'default'}
                                 onClick={() => { patchQuery({ dep: depositosFiltro ? '0' : '1' }) }}
                                 onDelete={() => { patchQuery({ dep: depositosFiltro ? '0' : '1' }) }}
-                                deleteIcon={depositosFiltro ? <FilterAltOffIcon /> : <FilterAltIcon />} />
+                                deleteIcon={depositosFiltro ? <FilterAltOffIcon fontSize="small" /> : <FilterAltIcon fontSize="small" />}
+                            />
                             <Chip
-                                onClick={() => { patchQuery({ emp: emprestimosFiltro ? '0' : '1' }) }}
-                                onDelete={() => { patchQuery({ emp: emprestimosFiltro ? '0' : '1' }) }}
+                                size="small"
                                 label={emprestimosFiltro ? t('extrato_filtros.remover_emprestimos') : t('extrato_filtros.incluir_emprestimos')}
                                 variant={emprestimosFiltro ? 'filled' : 'outlined'}
                                 color={emprestimosFiltro ? 'success' : 'default'}
-                                deleteIcon={emprestimosFiltro ? <FilterAltOffIcon /> : <FilterAltIcon />} />
-                        </Card>
-                        <Card sx={{ width: '100%' }}>
+                                onClick={() => { patchQuery({ emp: emprestimosFiltro ? '0' : '1' }) }}
+                                onDelete={() => { patchQuery({ emp: emprestimosFiltro ? '0' : '1' }) }}
+                                deleteIcon={emprestimosFiltro ? <FilterAltOffIcon fontSize="small" /> : <FilterAltIcon fontSize="small" />}
+                            />
+                        </Stack>
+
+                        {/* Tabela */}
+                        <Card sx={{ width: '100%', borderRadius: 3, boxShadow: '0 5px 22px rgba(0,0,0,0.08)' }}>
                             <Scrollbar sx={{ flexGrow: 1 }}>
                                 <Table>
                                     <TableHead>
                                         <TableRow>
-                                            <TableCell>
-                                                {t('operacao')}
-                                            </TableCell>
-                                            <TableCell>
-                                                {t('membro')}
-                                            </TableCell>
-                                            <TableCell>
-                                                {t('value')}
-                                            </TableCell>
-                                            <TableCell sortDirection="desc">
-                                                {t('data')}
-                                            </TableCell>
-                                            <TableCell>
-                                                {t('status')}
-                                            </TableCell>
+                                            <TableCell sx={headerSx}>{t('operacao')}</TableCell>
+                                            <TableCell sx={headerSx}>{t('membro')}</TableCell>
+                                            <TableCell sx={headerSx} sortDirection="desc">{t('data')}</TableCell>
+                                            <TableCell sx={{ ...headerSx, textAlign: 'right' }}>{t('value')}</TableCell>
+                                            <TableCell sx={headerSx}>{t('status')}</TableCell>
                                         </TableRow>
                                     </TableHead>
                                     <TableBody>
@@ -142,49 +164,80 @@ export default function Extrato() {
                                                 <TableRow key={`sk-${i}`}>
                                                     <TableCell><Skeleton variant="text" width="60%" /></TableCell>
                                                     <TableCell><Skeleton variant="text" width="50%" /></TableCell>
-                                                    <TableCell><Skeleton variant="text" width="40%" /></TableCell>
                                                     <TableCell><Skeleton variant="text" width="45%" /></TableCell>
+                                                    <TableCell><Skeleton variant="text" width="40%" /></TableCell>
                                                     <TableCell><Skeleton variant="text" width="35%" /></TableCell>
                                                 </TableRow>
                                             ))
-                                            : linhas.map((order) => (
-                                                <TableRow
-                                                    hover
-                                                    key={order.id}
-                                                >
-                                                    <TableCell>
-                                                        {order.tipo}
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        {order.nick}
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <DisplayValorMonetario>
-                                                            {order.valor}
-                                                        </DisplayValorMonetario>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        {order.date}
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        {order.status}
-                                                    </TableCell>
-                                                </TableRow>
-                                            ))}
+                                            : linhas.map((order) => {
+                                                const entrada = isDeposito(order.tipo)
+                                                return (
+                                                    <TableRow hover key={order.id}>
+                                                        <TableCell>
+                                                            <Stack direction="row" alignItems="center" spacing={1.5}>
+                                                                <Avatar
+                                                                    sx={{
+                                                                        width: 32,
+                                                                        height: 32,
+                                                                        bgcolor: entrada ? 'success.lightest' : 'warning.lightest',
+                                                                    }}
+                                                                >
+                                                                    {entrada
+                                                                        ? <ArrowDownwardIcon sx={{ fontSize: 18, color: 'success.dark' }} />
+                                                                        : <ArrowUpwardIcon sx={{ fontSize: 18, color: 'warning.dark' }} />
+                                                                    }
+                                                                </Avatar>
+                                                                <Typography variant="body2" fontWeight={600}>
+                                                                    {order.tipo}
+                                                                </Typography>
+                                                            </Stack>
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <Typography variant="body2" color="text.secondary">
+                                                                {order.nick}
+                                                            </Typography>
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <Typography variant="body2" color="text.secondary">
+                                                                {order.date}
+                                                            </Typography>
+                                                        </TableCell>
+                                                        <TableCell align="right">
+                                                            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.25 }}>
+                                                                <Typography
+                                                                    variant="body2"
+                                                                    fontWeight={600}
+                                                                    color={entrada ? 'success.dark' : 'text.primary'}
+                                                                >
+                                                                    {entrada ? '+' : '−'}
+                                                                </Typography>
+                                                                <DisplayValorMonetario
+                                                                    variant="body2"
+                                                                    fontWeight={600}
+                                                                    color={entrada ? 'success.dark' : 'text.primary'}
+                                                                >
+                                                                    {order.valor}
+                                                                </DisplayValorMonetario>
+                                                            </Box>
+                                                        </TableCell>
+                                                        <TableCell>
+                                                            <Chip
+                                                                label={statusLabel(order.status)}
+                                                                size="small"
+                                                                color={statusColor(order.status)}
+                                                                variant="filled"
+                                                            />
+                                                        </TableCell>
+                                                    </TableRow>
+                                                )
+                                            })}
                                     </TableBody>
                                 </Table>
                             </Scrollbar>
                         </Card>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'center'
-                            }}
-                        >
-                            <Pagination
-                                count={1}
-                                size="small"
-                            />
+
+                        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                            <Pagination count={1} size="small" color="primary" shape="rounded" />
                         </Box>
                     </Stack>
                 </Container>

--- a/front-caixinha/src/pages/feed/index.tsx
+++ b/front-caixinha/src/pages/feed/index.tsx
@@ -82,27 +82,26 @@ export default function Feed() {
             <Seo title={t('feed.seo')} />
             <Box
                 component="main"
-                sx={{
-                    flexGrow: 1,
-                    py: 8
-                }}
+                sx={{ flexGrow: 1, py: 8 }}
             >
-                <Container maxWidth="lg">
-                    <Stack spacing={1}>
+                <Container maxWidth="sm">
+                    <Box sx={{ mb: 3 }}>
                         <Typography
-                            color="text.secondary"
                             variant="overline"
+                            color="text.secondary"
+                            sx={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.5px', lineHeight: 2 }}
                         >
                             {t('feed.title')}
                         </Typography>
-                        <Typography variant="h4">
+                        <Typography variant="h4" fontWeight={700} sx={{ mt: 0.5 }}>
                             {t('feed.headlines')}
                         </Typography>
-                    </Stack>
-                    <Stack
-                        spacing={3}
-                        sx={{ mt: 3 }}
-                    >
+                        <Typography variant="body1" color="text.secondary" sx={{ mt: 0.5 }}>
+                            Aqui está o que suas conexões postaram
+                        </Typography>
+                    </Box>
+
+                    <Stack spacing={3}>
                         <SocialPostAdd />
                         {posts.map((post: any) => (
                             <SocialPostCard
@@ -116,20 +115,14 @@ export default function Feed() {
                                 likes={post.likes}
                                 media={post.media}
                                 message={post.message}
-
                                 addCommentView={addCommentView}
                             />
                         ))}
                     </Stack>
+
                     {hasMore && (
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                justifyContent: 'center',
-                                mt: 3
-                            }}
-                        >
-                            <Button variant="outlined" onClick={loadMore}>
+                        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+                            <Button variant="outlined" onClick={loadMore} sx={{ borderRadius: 3 }}>
                                 {t('loadmore')} ...
                             </Button>
                         </Box>

--- a/front-caixinha/src/pages/index.tsx
+++ b/front-caixinha/src/pages/index.tsx
@@ -3,9 +3,8 @@ import { BannerNovidades } from "@/components/bem-vindo/banner-novidades";
 import { Dicas } from "@/components/bem-vindo/dicas";
 import { AtalhoEmprestimo } from "@/components/bem-vindo/atalho-emprestimo";
 import { useSettings } from "@/hooks/useSettings";
-import { Box, Card, CardContent, Container, Typography, Stack } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 import { useRouter } from "next/router";
-import Grid from '@mui/material/Unstable_Grid2';
 import { Seo } from "@/components/Seo";
 import { getAleatorio } from "@/utils/utils";
 import { useUltimoEmprestimoPendente } from "@/features/caixinha/hooks/useUltimoEmprestimoPendente";
@@ -17,55 +16,64 @@ import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { useCaixinhaSelect } from '@/hooks/useCaixinhaSelect';
+import { SvgIconComponent } from '@mui/icons-material';
 
-const corAleatoriaCombinada = () => {
-  const cores = [
-    "#5475B8-#7691C6",
-    "#9176C6-#C7B9E1",
-    "#7A86B2-#A2A9CD",
-    "#6B82A3-#B3B1D4",
-    "#868DB6-#C8C4E5",
-    "#9599BA-#D0D2EA",
-    "#8988B8-#AFAEE1"
-  ]
-  return getAleatorio(cores)
+const GRADIENTS = [
+  'linear-gradient(135deg,#5475B8,#7691C6)',
+  'linear-gradient(135deg,#9176C6,#C7B9E1)',
+  'linear-gradient(135deg,#7A86B2,#A2A9CD)',
+  'linear-gradient(135deg,#6B82A3,#B3B1D4)',
+  'linear-gradient(135deg,#868DB6,#C8C4E5)',
+  'linear-gradient(135deg,#8988B8,#AFAEE1)',
+]
+
+const corAleatoriaCombinada = () => getAleatorio(GRADIENTS)
+
+interface GradientCardProps {
+  title: string
+  description: string
+  action: () => void
+  Icon: SvgIconComponent
 }
 
-const card = (title: string, description: string, action: any, icon: any) => {
-  const cor = corAleatoriaCombinada().split('-')
+const GradientCard = ({ title, description, action, Icon }: GradientCardProps) => {
+  const grad = corAleatoriaCombinada()
   return (
-    <Card
+    <Box
       onClick={action}
-      variant="elevation"
       sx={{
-        background: `linear-gradient(135deg, ${cor[0]}, ${cor[1]})`,
-        boxShadow: 6,
+        background: grad,
         borderRadius: 4,
-        cursor: 'pointer',
-        transition: 'transform 0.2s, box-shadow 0.2s',
-        '&:hover': {
-          transform: 'translateY(-4px) scale(1.03)',
-          boxShadow: 12,
-          opacity: 0.95
-        },
-        p: 2,
+        boxShadow: '0 6px 30px rgba(0,0,0,.12)',
+        px: 3,
+        py: 3.5,
         minHeight: 140,
+        color: '#fff',
+        cursor: 'pointer',
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
-      }}>
-      <CardContent>
-        <Stack direction="row" alignItems="center" spacing={2} mb={1}>
-          {icon}
-          <Typography variant="h5" component="div" fontWeight={700} color="white">
-            {title}
-          </Typography>
-        </Stack>
-        <Typography variant="body2" color="white">
-          {description}
-        </Typography>
-      </CardContent>
-    </Card>
+        transition: 'transform 0.2s, box-shadow 0.2s, opacity 0.2s',
+        '&:hover': {
+          transform: 'translateY(-4px) scale(1.03)',
+          boxShadow: '0 12px 40px rgba(0,0,0,.18)',
+          opacity: 0.96,
+        },
+      }}
+    >
+      <Icon sx={{ color: '#fff', fontSize: 36 }} />
+      <Typography
+        variant="h5"
+        fontWeight={700}
+        color="white"
+        sx={{ mt: 1.5 }}
+      >
+        {title}
+      </Typography>
+      <Typography variant="body2" color="white" sx={{ mt: 0.5, opacity: 0.92 }}>
+        {description}
+      </Typography>
+    </Box>
   )
 }
 
@@ -78,91 +86,93 @@ const Page = () => {
   const { resultado: ultimoEmprestimoAtalho } = useUltimoEmprestimoPendente()
   const { caixinha } = useCaixinhaSelect()
 
+  const quickCards: GradientCardProps[] = [
+    ...(caixinha?.id ? [{
+      title: 'Minha caixinha',
+      description: 'Resumo, extrato e atalhos',
+      action: () => router.push(`/caixinha/${caixinha.id}`),
+      Icon: DashboardIcon,
+    }] : []),
+    {
+      title: 'Caixinhas',
+      description: t('listar_caixinha_disponiveis'),
+      action: () => router.push('caixinhas-disponiveis'),
+      Icon: SavingsIcon,
+    },
+    {
+      title: 'Depositar',
+      description: t('depositar'),
+      action: () => router.push('deposito'),
+      Icon: AccountBalanceWalletIcon,
+    },
+    {
+      title: 'Pedir empréstimo',
+      description: t('emprestimo.solicitar_emprestimo'),
+      action: () => router.push('emprestimo'),
+      Icon: AddCircleOutlineIcon,
+    },
+  ]
+
   return (
-    <Box component="main"
-      sx={{
-        flexGrow: 1,
-        minHeight: '100vh',
-        py: 8,
-      }}>
+    <Box
+      component="main"
+      sx={{ flexGrow: 1, minHeight: '100vh', py: 8 }}
+    >
       <Container maxWidth={settings.stretch ? false : 'xl'}>
-        <Stack spacing={4} alignItems="center" mb={4}>
-          <Typography variant="h3" fontWeight={700} align="center">
-            Bem-vindo à Caixinha!
-          </Typography>
-        </Stack>
-        <Grid
-          container
-          spacing={{
-            xs: 3,
-            lg: 4
+        <Typography
+          variant="h3"
+          fontWeight={700}
+          align="center"
+          sx={{ mb: 4 }}
+        >
+          Bem-vindo à Caixinha!
+        </Typography>
+
+        {/* Banner + Dicas — proporção 1.4fr / 1fr
+            minmax(0,Xfr) é necessário para evitar overflow do react-slick */}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: 'minmax(0, 1.4fr) minmax(0, 1fr)' },
+            gap: 3,
+            alignItems: 'stretch',
+            mb: 3,
+            '& > *': { minWidth: 0 },
           }}
         >
-          <Grid xs={12} md={7}>
-            <BannerNovidades />
-          </Grid>
-          <Grid xs={12} md={5}>
-            {
-              ultimoEmprestimoAtalho && ultimoEmprestimoAtalho.exists
-                ? (
-                  <AtalhoEmprestimo emprestimo={ultimoEmprestimoAtalho.data} />
-                )
-                : (
-                  <Dicas
-                    sx={{ height: '100%' }}
-                    tips={[
-                      {
-                        title: t('dicas.0.title'),
-                        content: t('dicas.0.content'),
-                        link: {
-                          href: '/token-market',
-                          label: t('dicas.0.link_label')
-                        }
-                      },
-                      {
-                        title: t('dicas.1.title'),
-                        content: t('dicas.1.content')
-                      }
-                    ]}
-                  />
-                )
-            }
-          </Grid>
-          {caixinha?.id ? (
-            <Grid xs={12} md={7}>
-              {card(
-                "Minha caixinha",
-                "Resumo, extrato e atalhos",
-                () => { router.push(`/caixinha/${caixinha.id}`) },
-                <DashboardIcon sx={{ color: 'white', fontSize: 36 }} />
-              )}
-            </Grid>
-          ) : null}
-          <Grid xs={12} md={7}>
-            {card(
-              "Caixinhas",
-              t('listar_caixinha_disponiveis'),
-              () => { router.push('caixinhas-disponiveis') },
-              <SavingsIcon sx={{ color: 'white', fontSize: 36 }} />
-            )}
-          </Grid>
-          <Grid xs={12} md={7}>
-            {card(
-              "Depositar",
-              t('depositar'),
-              () => { router.push('deposito') },
-              <AccountBalanceWalletIcon sx={{ color: 'white', fontSize: 36 }} />
-            )}
-          </Grid>
-          <Grid xs={12} md={7}>
-            {card(
-              "Pedir emprestimo",
-              t('emprestimo.solicitar_emprestimo'),
-              () => { router.push('emprestimo') },
-              <AddCircleOutlineIcon sx={{ color: 'white', fontSize: 36 }} />
-            )}
-          </Grid>
-        </Grid>
+          <BannerNovidades />
+          {ultimoEmprestimoAtalho?.exists ? (
+            <AtalhoEmprestimo emprestimo={ultimoEmprestimoAtalho.data} />
+          ) : (
+            <Dicas
+              sx={{ height: '100%' }}
+              tips={[
+                {
+                  title: t('dicas.0.title'),
+                  content: t('dicas.0.content'),
+                  link: { href: '/token-market', label: t('dicas.0.link_label') },
+                },
+                {
+                  title: t('dicas.1.title'),
+                  content: t('dicas.1.content'),
+                },
+              ]}
+            />
+          )}
+        </Box>
+
+        {/* Atalhos rápidos — grid auto-fit */}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+            gap: 3,
+          }}
+        >
+          {quickCards.map((c) => (
+            <GradientCard key={c.title} {...c} />
+          ))}
+        </Box>
       </Container>
     </Box>
   )


### PR DESCRIPTION
## Summary

- Redesign visual fiel ao design system exportado do claude.ai/design (bundle **Caixinha - Telas Indigo**)
- 7 telas redesenhadas + 2 componentes compartilhados atualizados
- Toda funcionalidade de negócio preservada (hooks, API calls, navegação, auth)

## Telas alteradas

| Tela | Principais mudanças visuais |
|------|-----------------------------|
| **Home** | Grid CSS `minmax(0,1.4fr)/minmax(0,1fr)` para banner+dicas; `auto-fit minmax(240px)` para cards de atalho |
| **Caixinhas disponíveis** | Remove wrappers `Paper`, overline "Comunidade" + h4, grid `auto-fill` |
| **Minha Caixinha** | Overline + h4, espaçamento refinado nos botões de ação |
| **Empréstimo** | Slider de valor, botões de parcela (2×/3×/6×/12×), card de resumo lateral com parcelas do backend |
| **Depósito** | Botões de valor rápido (+50/100/200/500), seletor visual de método, QR PIX colapsável, badge de proteção |
| **Extrato** | Avatar com seta ↓ (depósito) / ↑ (empréstimo), valores coloridos (verde/normal), chips de status |
| **Feed** | Container `sm`, overline "Social" + h4 + subtitle |

## Componentes atualizados

- **`CaixinhaCard`**: header gradiente 140px substituindo imagens externas aleatórias
- **`CardTotal`**: `borderRadius: 5` (20px), `boxShadow` refinado, sem `CardContent` wrapper

## Bug fix incluído

Correção de overflow do `react-slick` Slider em CSS Grid: `1fr` → `minmax(0, 1fr)` + `& > *: { minWidth: 0 }` no container do grid de banner/dicas. Sem o fix, o Slider expandia a coluna para ~33 milhões de pixels.

## Test plan

- [ ] Home carrega com banner + dicas lado a lado e 3–4 cards de atalho abaixo
- [ ] Caixinhas disponíveis exibe grid de cards sem wrappers duplos
- [ ] Empréstimo: slider de valor funciona, botões de parcela selecionam corretamente, submit envia para backend
- [ ] Depósito: botões rápidos definem valor, QR PIX aparece ao selecionar Pix, upload de comprovante funciona
- [ ] Extrato: filtros de URL funcionam, ícones de tipo corretos, chips de status coloridos
- [ ] Minha Caixinha: botão "Início" navega para home, 4 botões de ação funcionam

🤖 Generated with [Claude Code](https://claude.com/claude-code)