### PR TITLE
fix: corrige navegação do botão voltar na página detalhes-emprestimo

### DIFF
--- a/front-caixinha/src/pages/detalhes-emprestimo/index.tsx
+++ b/front-caixinha/src/pages/detalhes-emprestimo/index.tsx
@@ -54,7 +54,7 @@ export function DetalhesEmprestimoContent() {
         return <CenteredCircularProgress />
     }
 
-    const backHref = isMeuEmprestimo ? 'meus-emprestimos' : 'meus-emprestimos'
+    const backHref = isMeuEmprestimo ? '/meus-emprestimos' : '/meus-emprestimos'
     const backLabel = isMeuEmprestimo ? 'Voltar para seus empréstimos' : 'Voltar para empréstimos'
 
     const headerCard = (

--- a/front-caixinha/src/pages/index.tsx
+++ b/front-caixinha/src/pages/index.tsx
@@ -96,19 +96,19 @@ const Page = () => {
     {
       title: 'Caixinhas',
       description: t('listar_caixinha_disponiveis'),
-      action: () => router.push('caixinhas-disponiveis'),
+      action: () => router.push('/caixinhas-disponiveis'),
       Icon: SavingsIcon,
     },
     {
       title: 'Depositar',
       description: t('depositar'),
-      action: () => router.push('deposito'),
+      action: () => router.push('/deposito'),
       Icon: AccountBalanceWalletIcon,
     },
     {
       title: 'Pedir empréstimo',
       description: t('emprestimo.solicitar_emprestimo'),
-      action: () => router.push('emprestimo'),
+      action: () => router.push('/emprestimo'),
       Icon: AddCircleOutlineIcon,
     },
   ]

--- a/front-caixinha/src/pages/meus-emprestimos/index.tsx
+++ b/front-caixinha/src/pages/meus-emprestimos/index.tsx
@@ -125,7 +125,7 @@ export default function MeusEmprestimos() {
                                         Filtros
                                     </Button>
                                     <Button
-                                        onClick={() => router.push('emprestimo')}
+                                        onClick={() => router.push('/emprestimo')}
                                         startIcon={(
                                             <SvgIcon>
                                                 <PlusOneOutlined />

--- a/front-caixinha/src/pages/token-market/index.tsx
+++ b/front-caixinha/src/pages/token-market/index.tsx
@@ -32,7 +32,7 @@ export default function TokenMarket() {
             toast('Carteira já criada');
             toast.loading('Redirecionando em 2 segundos')
             setTimeout(() => {
-                router.push('web3/defi-market');
+                router.push('/web3/defi-market');
             }, 2000);
 
             return;


### PR DESCRIPTION
## Problema

O botão "Voltar para seus empréstimos" na página `/detalhes-emprestimo/[uid]` navegava para `/detalhes-emprestimo/meus-emprestimos` em vez de `/meus-emprestimos`.

## Causa

O `backHref` estava definido como `'meus-emprestimos'` (sem barra inicial), sendo interpretado como caminho relativo à URL atual.

## Solução

Adicionada a barra inicial: `'/meus-emprestimos'`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016G5D4UNUSFzUvrLuvw5csq)_