### PR TITLE
feat(design): Onboarding, Meus emprestimos master-detail e Drawer indigo

### DIFF
--- a/front-caixinha/CLAUDE.md
+++ b/front-caixinha/CLAUDE.md
@@ -13,6 +13,18 @@ npm start        # Start production server
 
 There is no test runner configured — no Jest or Vitest setup exists.
 
+## Gotchas & conventions
+
+- **Auth is OAuth-only** (Keycloak + Google, `src/pages/api/auth/[...nextauth].ts`). Logged-in screens can't be reached in local dev without real credentials — verify authenticated UI via `npm run build` + code review; only logged-out routes (e.g. `/` onboarding) are browser-drivable locally.
+- **`next build` rewrites `tsconfig.json`** (`moduleResolution: node → bundler`). Revert it (`git checkout tsconfig.json`) after building.
+- **`CenteredCircularProgress` triggers a benign hydration warning** — it picks a random capicoin image at render (SSR/CSR mismatch). Pre-existing; not a regression.
+
+## Visual redesign (Indigo)
+
+- `DESIGN_TASKS.md` tracks the Indigo redesign screen-by-screen; update it when redesigning a screen.
+- Default theme preset is `indigo` (`#6366F1`, `src/theme/colors.ts`); `h1`–`h6` use Plus Jakarta Sans via `theme/base/create-typography.ts`.
+- Redesign idiom: MUI components + inline `sx` (theme palette keys like `primary.lightest`/`success.dark`, plus hardcoded hex where needed). Card radius `5` (borderRadius) / shadow `0 5px 22px rgba(0,0,0,0.08)`; reuse the `GRADIENTS` array (see `src/pages/index.tsx`, `src/components/caixinha/CaixinhaCard.tsx`).
+
 ## Architecture Overview
 
 **Next.js 16 + TypeScript** app using file-based routing under `src/pages/`. UI is built with **Material-UI (MUI) 5**. Data fetching uses **Axios** + **SWR** for caching. Auth is handled by **next-auth**.

--- a/front-caixinha/DESIGN_TASKS.md
+++ b/front-caixinha/DESIGN_TASKS.md
@@ -21,6 +21,44 @@ Raio de card: 20px | sombra: `0 5px 22px rgba(0,0,0,0.08)` | botão: radius 12px
 | 05 | Depósito | `src/pages/deposito/index.tsx` | ✅ concluído |
 | 06 | Extrato | `src/pages/extrato/index.tsx` | ✅ concluído |
 | 07 | Feed | `src/pages/feed/index.tsx` | ✅ concluído |
+| 08 | Onboarding / Boas-vindas (gate deslogados) | `src/components/bem-vindo/onboarding.tsx` + `src/pages/index.tsx` | ✅ concluído |
+| 09 | Meus empréstimos (master-detail) | `src/pages/meus-emprestimos/index.tsx` | ✅ concluído |
+| 10 | Menu lateral (Drawer indigo) | `src/components/Drawer.tsx` | ✅ concluído |
+
+---
+
+## TASK-08 — Onboarding / Boas-vindas
+
+**Arquivos:** `src/components/bem-vindo/onboarding.tsx` (novo), `src/pages/index.tsx` (gate).
+Ref. design: `indigo/new-screens.jsx → OnboardingScreen`.
+
+- Tela standalone (fora do `Layout`, com `ThemeProvider` indigo próprio) mostrada quando `useSession().status === 'unauthenticated'`.
+- Card 880px: painel esquerdo com `person-standing.png` + pill "CapiCoin chegou"; direito com logo, título "Bem-vindo à Caixinha!", 3 features e CTAs.
+- CTAs "Começar agora" / "Já tenho conta" → `signIn()` (fluxo next-auth preservado).
+- Logado: Home dashboard intacta. Loading: `CenteredCircularProgress`.
+
+## TASK-09 — Meus empréstimos (master-detail)
+
+**Arquivo:** `src/pages/meus-emprestimos/index.tsx`.
+Ref. design: `indigo/meus-emprestimos.jsx`. Novos componentes em `src/components/meus-emprestimos/`:
+`stat-card.tsx`, `emprestimo-list-item.tsx`, `emprestimo-detail.tsx`, `loan-progress.tsx`, `loan-status.tsx`.
+Util novo: `src/features/caixinha/utils/flatten-emprestimos.ts` (mapeia `LoansForApprove` → view-model + status).
+
+- 3 `StatCard` (Total emprestado = `totalGeral`, Em aberto = nº não-quitados, Pendente aprovação = `totalPendente`).
+- Grid `360px minmax(0,1fr)`: lista de cards clicáveis + busca à esquerda, `EmprestimoDetail` à direita.
+- Mobile (`< lg`): só a lista; clique navega para `/detalhes-emprestimo/{uid}`.
+- Preservado: `useMeusEmprestimos`, `filterMeusEmprestimos`, loading/error (`/error`), navegação real
+  ("Pagar parcela"/"Ver detalhes" → `/detalhes-emprestimo/{uid}`, "Renegociar" → `/renegociacao`, "Novo empréstimo" → `/emprestimo`).
+- Componentes antigos (`filtros`, `meus-emprestimos-table`, `meus-emprestimos-list-summary`, `meu-emprestimos-list-container`) deixaram de ser referenciados (não deletados).
+
+## TASK-10 — Menu lateral (Drawer indigo)
+
+**Arquivo:** `src/components/Drawer.tsx`.
+Ref. design: `indigo/shell.jsx → Drawer/DrawerItem`.
+
+- Header com avatar `primary.light` + `capicoin.png` + wordmark "Caixinha".
+- Itens `borderRadius 12`, item da rota atual (via `router.pathname`) destacado (`primary.light` / `primary.dark`), hover suave, chips New/Beta à direita.
+- Preservado: todas as rotas/hrefs, `CustomChips`, item condicional `caixinha?.id` → "Minha caixinha", `open`/`handleDrawerClose`.
 
 ---
 

--- a/front-caixinha/src/components/Drawer.tsx
+++ b/front-caixinha/src/components/Drawer.tsx
@@ -1,19 +1,11 @@
 import * as React from 'react';
-import { styled, useTheme } from '@mui/material/styles';
-import List from '@mui/material/List';
-import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
-import ListItem from '@mui/material/ListItem';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
 import {
     AttachMoney,
     ListAltSharp,
     Home,
     ShowChartOutlined,
-    ChevronRight,
     ChevronLeft,
     CurrencyBitcoin,
     SavingsOutlined,
@@ -26,128 +18,102 @@ import {
     ChatBubble,
     Dashboard,
 } from '@mui/icons-material';
-import { Chip, Link } from '@mui/material';
+import { Avatar, Box, Chip, Divider, Link, Stack, Typography } from '@mui/material';
+import { useRouter } from 'next/router';
 import { useCaixinhaSelect } from '@/hooks/useCaixinhaSelect';
 
-const drawerWidth = 340;
-
-const DrawerHeader = styled('div')(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: theme.spacing(0, 1),
-    ...theme.mixins.toolbar,
-}));
+const drawerWidth = 320;
 
 const routes = [
-    {
-        text: 'Caixinhas',
-        path: '/caixinhas-disponiveis',
-        icon: <Savings />
-    },
-    {
-        text: 'Novo emprestimo',
-        path: '/emprestimo',
-        icon: <FiberNew />
-    },
-    {
-        text: 'Meus emprestimos',
-        path: '/meus-emprestimos',
-        icon: <AssuredWorkload />
-    },
-    {
-        text: 'Novo Deposito',
-        path: '/deposito',
-        icon: <AttachMoney />
-    },
-    {
-        text: 'Extrato',
-        path: '/extrato',
-        icon: <ListAltSharp />
-    }
+    { text: 'Caixinhas', path: '/caixinhas-disponiveis', icon: <Savings /> },
+    { text: 'Novo emprestimo', path: '/emprestimo', icon: <FiberNew /> },
+    { text: 'Meus emprestimos', path: '/meus-emprestimos', icon: <AssuredWorkload /> },
+    { text: 'Novo Deposito', path: '/deposito', icon: <AttachMoney /> },
+    { text: 'Extrato', path: '/extrato', icon: <ListAltSharp /> },
 ]
 
 const carteiraRoutes = [
-    {
-        text: 'Carteira',
-        path: '/carteira',
-        icon: <ShowChartOutlined />
-    },
-    {
-        text: 'Meus ativos',
-        path: '/carteira/meus-ativos',
-        icon: <AccountBalanceWallet />
-    },
-    {
-        text: 'Novo aporte',
-        path: '/carteira/aporte',
-        icon: <SavingsOutlined />,
-        newFeature: true,
-        beta: true,
-    },
-    {
-        text: 'Alt-Coins',
-        path: '/token-market',
-        icon: <CurrencyBitcoin />,
-        newFeature: true,
-        beta: true,
-    },
-    {
-        text: 'NFT',
-        path: '/web3/meus-nft',
-        icon: <EmojiEvents />,
-        newFeature: true,
-        beta: false,
-    }
+    { text: 'Carteira', path: '/carteira', icon: <ShowChartOutlined /> },
+    { text: 'Meus ativos', path: '/carteira/meus-ativos', icon: <AccountBalanceWallet /> },
+    { text: 'Novo aporte', path: '/carteira/aporte', icon: <SavingsOutlined />, newFeature: true, beta: true },
+    { text: 'Alt-Coins', path: '/token-market', icon: <CurrencyBitcoin />, newFeature: true, beta: true },
+    { text: 'NFT', path: '/web3/meus-nft', icon: <EmojiEvents />, newFeature: true, beta: false },
 ]
 
 const socialRoutes = [
-    {
-        text: 'Feed',
-        path: 'feed',
-        icon: <Reddit />,
-        newFeature: true,
-        beta: false,
-    },
-    {
-        text: 'Chat',
-        path: 'chat',
-        icon: <ChatBubble />,
-        newFeature: true,
-        beta: true
-    }
+    { text: 'Feed', path: 'feed', icon: <Reddit />, newFeature: true, beta: false },
+    { text: 'Chat', path: 'chat', icon: <ChatBubble />, newFeature: true, beta: true },
 ]
 
 const CustomChips = ({ it }: { it: any }) => (
     <>
-        {it.newFeature && (
-            <Chip
-                color="primary"
-                label="New"
-                size="small"
-            />
-        )}
-        {it?.beta && (
-            <Chip
-                color="warning"
-                label="Beta"
-                size="small"
-            />
-        )}
+        {it.newFeature && <Chip color="primary" label="New" size="small" />}
+        {it?.beta && <Chip color="warning" label="Beta" size="small" />}
     </>
 )
 
+const normalize = (p: string) => (p.startsWith('/') ? p : `/${p}`)
+
+interface NavItemProps {
+    text: string
+    path: string
+    icon: React.ReactNode
+    active: boolean
+    onClick?: () => void
+    it?: any
+}
+
+const NavItem = ({ text, path, icon, active, onClick, it }: NavItemProps) => (
+    <Link
+        href={normalize(path)}
+        onClick={onClick}
+        underline="none"
+        sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2.25,
+            px: 2.5,
+            py: 1.4,
+            mx: 1.5,
+            my: '2px',
+            borderRadius: 3,
+            cursor: 'pointer',
+            fontSize: 15,
+            fontWeight: active ? 600 : 500,
+            color: active ? 'primary.dark' : 'text.primary',
+            bgcolor: active ? 'primary.light' : 'transparent',
+            transition: 'background .15s, color .15s',
+            '&:hover': { bgcolor: active ? 'primary.light' : 'rgba(0,0,0,.04)' },
+            '& .nav-icon': {
+                display: 'flex',
+                color: active ? 'primary.dark' : 'text.secondary',
+                fontSize: 22,
+            },
+        }}
+    >
+        <Box className="nav-icon">{icon}</Box>
+        <Box component="span" sx={{ flex: 1 }}>{text}</Box>
+        {it && (it.newFeature || it.beta) && (
+            <Stack direction="row" spacing={0.75} sx={{ ml: 'auto' }}>
+                <CustomChips it={it} />
+            </Stack>
+        )}
+    </Link>
+)
+
 export default function MiniDrawer(props: any) {
-    const {
-        open,
-        handleDrawerClose,
-    } = props
-    const theme = useTheme()
+    const { open, handleDrawerClose } = props
+    const router = useRouter()
     const { caixinha } = useCaixinhaSelect()
+
+    const isActive = (path: string) => {
+        const p = normalize(path)
+        return router.pathname === p || router.pathname.startsWith(`${p}/`)
+    }
 
     return (
         <Drawer
-            anchor={'left'}
+            anchor="left"
             open={open}
             onClose={handleDrawerClose}
             sx={{
@@ -156,150 +122,97 @@ export default function MiniDrawer(props: any) {
                 '& .MuiDrawer-paper': {
                     width: drawerWidth,
                     boxSizing: 'border-box',
+                    borderRight: 'none',
+                    boxShadow: '0 8px 40px rgba(0,0,0,0.08)',
                 },
             }}
         >
-            <DrawerHeader>
-                <IconButton onClick={handleDrawerClose}>
-                    {theme.direction === 'rtl' ? <ChevronRight /> : <ChevronLeft />}
+            {/* Header */}
+            <Stack direction="row" alignItems="center" spacing={1.5} sx={{ p: '20px 20px 12px' }}>
+                <Avatar sx={{ width: 40, height: 40, bgcolor: 'primary.light' }}>
+                    <Box
+                        component="img"
+                        src="/assets/crypto/images/capicoin.png"
+                        alt=""
+                        sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                    />
+                </Avatar>
+                <Typography sx={{ fontWeight: 800, fontSize: 22, color: 'primary.main', flex: 1 }}>
+                    Caixinha
+                </Typography>
+                <IconButton onClick={handleDrawerClose} size="small" sx={{ color: 'text.secondary' }}>
+                    <ChevronLeft />
                 </IconButton>
-            </DrawerHeader>
-            <Divider />
-            <List>
-                {caixinha?.id ? (
-                    <ListItem disablePadding sx={{ display: 'block' }}>
-                        <ListItemButton
-                            LinkComponent={Link}
-                            href={`/caixinha/${caixinha.id}`}
-                            onClick={handleDrawerClose}
-                            sx={{
-                                minHeight: 48,
-                                justifyContent: open ? 'initial' : 'center',
-                                px: 2.5,
-                            }}
-                        >
-                            <ListItemIcon
-                                sx={{
-                                    minWidth: 0,
-                                    mr: open ? 3 : 'auto',
-                                    justifyContent: 'center',
-                                }}
-                            >
-                                <Dashboard />
-                            </ListItemIcon>
-                            <ListItemText primary="Minha caixinha" sx={{ opacity: open ? 1 : 0 }} />
-                        </ListItemButton>
-                    </ListItem>
-                ) : null}
-                {routes.map((it, index) => (
-                    <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-                        <ListItemButton
-                            LinkComponent={Link}
-                            href={it.path}
-                            sx={{
-                                minHeight: 48,
-                                justifyContent: open ? 'initial' : 'center',
-                                px: 2.5,
-                            }}
-                        >
-                            <ListItemIcon
-                                sx={{
-                                    minWidth: 0,
-                                    mr: open ? 3 : 'auto',
-                                    justifyContent: 'center',
-                                }}
-                            >
-                                {it.icon}
-                            </ListItemIcon>
-                            <ListItemText primary={it.text} sx={{ opacity: open ? 1 : 0 }} />
-                            <CustomChips it={it} />
-                        </ListItemButton>
-                    </ListItem>
+            </Stack>
+            <Divider sx={{ borderColor: 'divider' }} />
+
+            {/* Group 1 — caixinha */}
+            <Box sx={{ py: 1 }}>
+                {caixinha?.id && (
+                    <NavItem
+                        text="Minha caixinha"
+                        path={`/caixinha/${caixinha.id}`}
+                        icon={<Dashboard />}
+                        active={router.pathname.startsWith('/caixinha/')}
+                        onClick={handleDrawerClose}
+                    />
+                )}
+                {routes.map((it) => (
+                    <NavItem
+                        key={it.path}
+                        text={it.text}
+                        path={it.path}
+                        icon={it.icon}
+                        active={isActive(it.path)}
+                        onClick={handleDrawerClose}
+                        it={it}
+                    />
                 ))}
-            </List>
-            <Divider />
-            <List>
-                {carteiraRoutes.map((it, index) => (
-                    <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-                        <ListItemButton
-                            LinkComponent={Link}
-                            href={it.path}
-                            sx={{
-                                minHeight: 48,
-                                justifyContent: open ? 'initial' : 'center',
-                                px: 2.5,
-                            }}
-                        >
-                            <ListItemIcon
-                                sx={{
-                                    minWidth: 0,
-                                    mr: open ? 3 : 'auto',
-                                    justifyContent: 'center',
-                                }}
-                            >
-                                {it.icon}
-                            </ListItemIcon>
-                            <ListItemText primary={it.text} sx={{ opacity: open ? 1 : 0 }} />
-                            <CustomChips it={it} />
-                        </ListItemButton>
-                    </ListItem>
+            </Box>
+            <Divider sx={{ borderColor: 'divider' }} />
+
+            {/* Group 2 — carteira */}
+            <Box sx={{ py: 1 }}>
+                {carteiraRoutes.map((it) => (
+                    <NavItem
+                        key={it.path}
+                        text={it.text}
+                        path={it.path}
+                        icon={it.icon}
+                        active={isActive(it.path)}
+                        onClick={handleDrawerClose}
+                        it={it}
+                    />
                 ))}
-            </List>
-            <Divider />
-            <List>
-                {socialRoutes.map((it, index) => (
-                    <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-                        <ListItemButton
-                            LinkComponent={Link}
-                            href={it.path}
-                            sx={{
-                                minHeight: 48,
-                                justifyContent: open ? 'initial' : 'center',
-                                px: 2.5,
-                            }}
-                        >
-                            <ListItemIcon
-                                sx={{
-                                    minWidth: 0,
-                                    mr: open ? 3 : 'auto',
-                                    justifyContent: 'center',
-                                }}
-                            >
-                                {it.icon}
-                            </ListItemIcon>
-                            <ListItemText primary={it.text} sx={{ opacity: open ? 1 : 0 }} />
-                            <CustomChips it={it} />
-                        </ListItemButton>
-                    </ListItem>
+            </Box>
+            <Divider sx={{ borderColor: 'divider' }} />
+
+            {/* Group 3 — social */}
+            <Box sx={{ py: 1 }}>
+                {socialRoutes.map((it) => (
+                    <NavItem
+                        key={it.path}
+                        text={it.text}
+                        path={it.path}
+                        icon={it.icon}
+                        active={isActive(it.path)}
+                        onClick={handleDrawerClose}
+                        it={it}
+                    />
                 ))}
-            </List>
-            <Divider />
-            <List>
-                {['Home'].map((text, _index) => (
-                    <ListItem key={text} disablePadding sx={{ display: 'block' }}>
-                        <ListItemButton
-                            LinkComponent={Link}
-                            href="/"
-                            sx={{
-                                minHeight: 48,
-                                justifyContent: open ? 'initial' : 'center',
-                                px: 2.5,
-                            }}
-                        >
-                            <ListItemIcon
-                                sx={{
-                                    minWidth: 0,
-                                    mr: open ? 3 : 'auto',
-                                    justifyContent: 'center',
-                                }}
-                            >
-                                <Home />
-                            </ListItemIcon>
-                            <ListItemText primary={text} sx={{ opacity: open ? 1 : 0 }} />
-                        </ListItemButton>
-                    </ListItem>
-                ))}
-            </List>
+            </Box>
+            <Divider sx={{ borderColor: 'divider' }} />
+
+            {/* Home */}
+            <Box sx={{ py: 1 }}>
+                <NavItem
+                    text="Home"
+                    path="/"
+                    icon={<Home />}
+                    active={router.pathname === '/'}
+                    onClick={handleDrawerClose}
+                />
+            </Box>
         </Drawer>
     );
 }

--- a/front-caixinha/src/components/bem-vindo/onboarding.tsx
+++ b/front-caixinha/src/components/bem-vindo/onboarding.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import {
+    Avatar,
+    Box,
+    Button,
+    Card,
+    CssBaseline,
+    Stack,
+    ThemeProvider,
+    Typography,
+} from '@mui/material';
+import Savings from '@mui/icons-material/Savings';
+import AccountBalance from '@mui/icons-material/AccountBalance';
+import ShowChart from '@mui/icons-material/ShowChart';
+import { signIn } from 'next-auth/react';
+import { createTheme } from '@/theme/theme';
+import { Seo } from '@/components/Seo';
+
+const FEATURES = [
+    {
+        icon: Savings,
+        title: 'Caixinhas coletivas',
+        desc: 'Junte dinheiro com amigos e acompanhe a meta de cada grupo.',
+    },
+    {
+        icon: AccountBalance,
+        title: 'Empréstimos da galera',
+        desc: 'Peça e pague empréstimos financiados pela própria comunidade.',
+    },
+    {
+        icon: ShowChart,
+        title: 'Carteira e CapiCoin',
+        desc: 'Invista, acompanhe seus ativos e a nova moeda da Caixinha.',
+    },
+]
+
+// Standalone welcome screen shown to logged-out users (rendered outside Layout,
+// so it carries its own indigo theme). CTAs kick off the next-auth sign-in flow.
+export const Onboarding = () => {
+    const theme = createTheme({
+        colorPreset: 'indigo',
+        contrast: 'normal',
+        direction: 'ltr',
+        paletteMode: 'light',
+        responsiveFontSizes: true,
+    })
+
+    const handleStart = () => signIn()
+
+    return (
+        <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <Seo title="Bem-vindo" />
+            <Box
+                sx={{
+                    minHeight: '100vh',
+                    bgcolor: 'primary.lightest',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    p: { xs: 3, md: 7 },
+                }}
+            >
+                <Card
+                    sx={{
+                        width: '100%',
+                        maxWidth: 880,
+                        borderRadius: 5,
+                        boxShadow: '0 5px 22px rgba(0,0,0,0.08)',
+                        overflow: 'hidden',
+                        display: 'grid',
+                        gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                    }}
+                >
+                    {/* Left — illustration panel */}
+                    <Box
+                        sx={{
+                            display: { xs: 'none', md: 'flex' },
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: 2.25,
+                            p: '40px 36px',
+                            background: 'linear-gradient(160deg,#EBEEFE,#F5F7FF)',
+                        }}
+                    >
+                        <Box
+                            component="img"
+                            src="/assets/person-standing.png"
+                            alt=""
+                            sx={{ width: 168 }}
+                        />
+                        <Stack
+                            direction="row"
+                            alignItems="center"
+                            spacing={1.25}
+                            sx={{
+                                bgcolor: '#fff',
+                                borderRadius: 999,
+                                px: 2,
+                                py: 1,
+                                boxShadow: '0 1px 2px rgba(0,0,0,0.08)',
+                            }}
+                        >
+                            <Box
+                                component="img"
+                                src="/assets/crypto/images/capicoin.png"
+                                alt=""
+                                sx={{ width: 26, height: 26, objectFit: 'contain' }}
+                            />
+                            <Typography
+                                sx={{ fontWeight: 700, fontSize: 15, color: 'primary.main' }}
+                            >
+                                CapiCoin chegou
+                            </Typography>
+                        </Stack>
+                    </Box>
+
+                    {/* Right — copy + CTAs */}
+                    <Box sx={{ p: { xs: '32px 24px', md: '44px 40px' }, display: 'flex', flexDirection: 'column' }}>
+                        <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 2.25 }}>
+                            <Avatar sx={{ width: 36, height: 36, bgcolor: 'primary.light' }}>
+                                <Box
+                                    component="img"
+                                    src="/assets/crypto/images/capicoin.png"
+                                    alt=""
+                                    sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                                />
+                            </Avatar>
+                            <Typography sx={{ fontWeight: 800, fontSize: 20, color: 'primary.main' }}>
+                                Caixinha
+                            </Typography>
+                        </Stack>
+
+                        <Typography
+                            variant="h4"
+                            sx={{ fontWeight: 700, fontSize: 32, lineHeight: 1.15, mb: 1.25 }}
+                        >
+                            Bem-vindo à Caixinha!
+                        </Typography>
+                        <Typography sx={{ fontSize: 15, color: 'text.secondary', mb: 3.25, lineHeight: 1.5 }}>
+                            Sua poupança entre amigos com mais transparência, segurança e praticidade.
+                        </Typography>
+
+                        <Stack spacing={2.25} sx={{ mb: 3.75 }}>
+                            {FEATURES.map((f) => {
+                                const Icon = f.icon
+                                return (
+                                    <Stack key={f.title} direction="row" spacing={1.75} alignItems="flex-start">
+                                        <Avatar sx={{ width: 42, height: 42, bgcolor: 'primary.light' }}>
+                                            <Icon sx={{ fontSize: 22, color: 'primary.main' }} />
+                                        </Avatar>
+                                        <Box>
+                                            <Typography sx={{ fontWeight: 600, fontSize: 15 }}>
+                                                {f.title}
+                                            </Typography>
+                                            <Typography sx={{ fontSize: 13.5, color: 'text.secondary', mt: 0.25, lineHeight: 1.45 }}>
+                                                {f.desc}
+                                            </Typography>
+                                        </Box>
+                                    </Stack>
+                                )
+                            })}
+                        </Stack>
+
+                        <Stack spacing={1.5} sx={{ mt: 'auto' }}>
+                            <Button
+                                variant="contained"
+                                size="large"
+                                fullWidth
+                                onClick={handleStart}
+                                sx={{ borderRadius: 3, textTransform: 'none', fontWeight: 600 }}
+                            >
+                                Começar agora
+                            </Button>
+                            <Button
+                                variant="text"
+                                fullWidth
+                                onClick={handleStart}
+                                sx={{ borderRadius: 3, textTransform: 'none', fontWeight: 600 }}
+                            >
+                                Já tenho conta
+                            </Button>
+                        </Stack>
+                    </Box>
+                </Card>
+            </Box>
+        </ThemeProvider>
+    );
+};

--- a/front-caixinha/src/components/meus-emprestimos/emprestimo-detail.tsx
+++ b/front-caixinha/src/components/meus-emprestimos/emprestimo-detail.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+import { Avatar, Box, Button, Card, Divider, Stack, Typography } from '@mui/material';
+import Check from '@mui/icons-material/Check';
+import Schedule from '@mui/icons-material/Schedule';
+import ReceiptLong from '@mui/icons-material/ReceiptLong';
+import type { EmprestimoView } from '@/features/caixinha/utils/flatten-emprestimos';
+import { brl } from '@/features/caixinha/utils/flatten-emprestimos';
+import { LoanProgress } from './loan-progress';
+import { SoftChip, statusPalette } from './loan-status';
+
+interface Props {
+    e: EmprestimoView
+    compact?: boolean
+    onDetails: (uid: string) => void
+    onRenegociar: (uid: string) => void
+}
+
+interface ParcelaRow {
+    label: string
+    valor: number
+    paid: boolean
+}
+
+function buildParcelas(e: EmprestimoView): ParcelaRow[] {
+    if (e.billingDates.length) {
+        return e.billingDates.map((b, i) => ({
+            label: b.data || `Parcela ${i + 1}`,
+            valor: b.valor ?? e.valorParcela,
+            paid: b.valor != null,
+        }))
+    }
+    return Array.from({ length: e.parcelas }).map((_, i) => ({
+        label: `Parcela ${i + 1}`,
+        valor: e.valorParcela,
+        paid: i < e.pagas,
+    }))
+}
+
+export const EmprestimoDetail = ({ e, compact, onDetails, onRenegociar }: Props) => {
+    const pct = e.parcelas ? Math.round((e.pagas / e.parcelas) * 100) : 0
+    const barColor = `${statusPalette(e.status)}.main`
+    const parcelas = buildParcelas(e)
+    const resumo: [string, string][] = [
+        ['Valor da parcela', brl(e.valorParcela)],
+        ['Restante', brl(e.restante)],
+        ['Próxima parcela', e.proxima || '—'],
+    ]
+
+    return (
+        <Card sx={{ p: compact ? 2.5 : 3.5, borderRadius: 5, boxShadow: '0 5px 22px rgba(0,0,0,0.08)' }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2} sx={{ mb: 2.5 }}>
+                <Box>
+                    <Typography variant="overline" sx={{ color: 'text.secondary', letterSpacing: '.5px' }}>
+                        {e.caixinha}
+                    </Typography>
+                    <Typography sx={{ fontWeight: 700, fontSize: compact ? 24 : 30 }}>{brl(e.valor)}</Typography>
+                </Box>
+                <SoftChip status={e.status} />
+            </Stack>
+
+            <LoanProgress pct={pct} color={barColor as string} />
+            <Stack direction="row" justifyContent="space-between" sx={{ fontSize: 13, color: 'text.secondary', mt: 1, mb: 3 }}>
+                <span>
+                    {e.pagas} de {e.parcelas} parcelas pagas
+                </span>
+                <span>{pct}%</span>
+            </Stack>
+
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(3, 1fr)',
+                    gap: 2,
+                    mb: 3,
+                }}
+            >
+                {resumo.map(([k, v]) => (
+                    <Box key={k}>
+                        <Typography variant="overline" sx={{ color: 'text.secondary', letterSpacing: '.5px' }}>
+                            {k}
+                        </Typography>
+                        <Typography sx={{ fontWeight: 600, fontSize: compact ? 14 : 16, mt: 0.5 }}>{v}</Typography>
+                    </Box>
+                ))}
+            </Box>
+
+            <Typography sx={{ fontWeight: 700, fontSize: 15, mb: 0.5 }}>Parcelas</Typography>
+            <Box sx={{ mb: 3 }}>
+                {parcelas.map((p, i) => (
+                    <Stack
+                        key={i}
+                        direction="row"
+                        alignItems="center"
+                        spacing={1.5}
+                        sx={{
+                            py: 1,
+                            borderBottom: i < parcelas.length - 1 ? '1px solid' : 'none',
+                            borderColor: 'divider',
+                        }}
+                    >
+                        <Avatar sx={{ width: 30, height: 30, bgcolor: p.paid ? 'success.lightest' : '#F3F4F6' }}>
+                            {p.paid ? (
+                                <Check sx={{ fontSize: 16, color: 'success.dark' }} />
+                            ) : (
+                                <Schedule sx={{ fontSize: 16, color: 'text.secondary' }} />
+                            )}
+                        </Avatar>
+                        <Typography sx={{ flex: 1, fontSize: 13.5 }}>{p.label}</Typography>
+                        <Typography sx={{ fontSize: 13.5, fontWeight: 600, color: p.paid ? 'success.dark' : 'text.secondary' }}>
+                            {brl(p.valor)}
+                        </Typography>
+                    </Stack>
+                ))}
+            </Box>
+
+            {e.status !== 'Quitado' ? (
+                <Stack direction="row" spacing={1.5}>
+                    <Button
+                        variant="contained"
+                        fullWidth
+                        onClick={() => onDetails(e.uid)}
+                        sx={{ borderRadius: 3, textTransform: 'none', fontWeight: 600 }}
+                    >
+                        Pagar parcela
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        fullWidth
+                        onClick={() => onRenegociar(e.uid)}
+                        sx={{ borderRadius: 3, textTransform: 'none', fontWeight: 600 }}
+                    >
+                        Renegociar
+                    </Button>
+                </Stack>
+            ) : (
+                <Button
+                    variant="outlined"
+                    fullWidth
+                    startIcon={<ReceiptLong />}
+                    onClick={() => onDetails(e.uid)}
+                    sx={{ borderRadius: 3, textTransform: 'none', fontWeight: 600 }}
+                >
+                    Ver comprovante
+                </Button>
+            )}
+        </Card>
+    );
+};

--- a/front-caixinha/src/components/meus-emprestimos/emprestimo-list-item.tsx
+++ b/front-caixinha/src/components/meus-emprestimos/emprestimo-list-item.tsx
@@ -1,0 +1,49 @@
+import { Box, Stack, Typography } from '@mui/material';
+import type { EmprestimoView } from '@/features/caixinha/utils/flatten-emprestimos';
+import { brl } from '@/features/caixinha/utils/flatten-emprestimos';
+import { LoanProgress } from './loan-progress';
+import { SoftChip, statusPalette } from './loan-status';
+
+interface Props {
+    e: EmprestimoView
+    active?: boolean
+    onClick: (uid: string) => void
+}
+
+export const EmprestimoListItem = ({ e, active, onClick }: Props) => {
+    const pct = e.parcelas ? Math.round((e.pagas / e.parcelas) * 100) : 0
+    const barColor = `${statusPalette(e.status)}.main`
+    return (
+        <Box
+            onClick={() => onClick(e.uid)}
+            sx={{
+                p: 2,
+                borderRadius: 4,
+                cursor: 'pointer',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1.25,
+                border: '1px solid',
+                borderColor: active ? 'primary.main' : 'divider',
+                bgcolor: active ? 'primary.lightest' : 'background.paper',
+                transition: 'border-color .15s, background .15s',
+                '&:hover': { borderColor: 'primary.light' },
+            }}
+        >
+            <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1}>
+                <Box>
+                    <Typography sx={{ fontWeight: 600, fontSize: 14.5 }}>{e.caixinha}</Typography>
+                    <Typography sx={{ fontWeight: 700, fontSize: 18, mt: 0.25 }}>{brl(e.valor)}</Typography>
+                </Box>
+                <SoftChip status={e.status} small />
+            </Stack>
+            <LoanProgress pct={pct} color={barColor as string} />
+            <Stack direction="row" justifyContent="space-between" sx={{ fontSize: 12.5, color: 'text.secondary' }}>
+                <span>
+                    {e.pagas}/{e.parcelas} parcelas
+                </span>
+                <span>{e.proxima ? `Próxima: ${e.proxima}` : e.status === 'Quitado' ? 'Quitado' : '—'}</span>
+            </Stack>
+        </Box>
+    );
+};

--- a/front-caixinha/src/components/meus-emprestimos/loan-progress.tsx
+++ b/front-caixinha/src/components/meus-emprestimos/loan-progress.tsx
@@ -1,0 +1,15 @@
+import { Box } from '@mui/material';
+
+export const LoanProgress = ({ pct, color }: { pct: number; color: string }) => (
+    <Box sx={{ height: 8, borderRadius: 999, bgcolor: '#E5E7EB', overflow: 'hidden' }}>
+        <Box
+            sx={{
+                width: `${Math.min(Math.max(pct, 0), 100)}%`,
+                height: '100%',
+                bgcolor: color,
+                borderRadius: 999,
+                transition: 'width .3s',
+            }}
+        />
+    </Box>
+);

--- a/front-caixinha/src/components/meus-emprestimos/loan-status.tsx
+++ b/front-caixinha/src/components/meus-emprestimos/loan-status.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@mui/material';
+import type { LoanStatus } from '@/features/caixinha/utils/flatten-emprestimos';
+
+// palette key per status (uses Devias palette shades: main / lightest)
+const PALETTE: Record<LoanStatus, 'warning' | 'success' | 'primary'> = {
+    Pendente: 'warning',
+    'Em dia': 'success',
+    Quitado: 'primary',
+}
+
+export const statusPalette = (status: LoanStatus) => PALETTE[status]
+
+// Soft (tinted) status chip matching the indigo design language.
+export const SoftChip = ({ status, small }: { status: LoanStatus; small?: boolean }) => {
+    const key = PALETTE[status]
+    return (
+        <Box
+            component="span"
+            sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                bgcolor: `${key}.lightest`,
+                color: `${key}.dark`,
+                fontWeight: 600,
+                fontSize: small ? 11 : 13,
+                borderRadius: 999,
+                px: small ? 1.1 : 1.5,
+                py: small ? 0.25 : 0.6,
+                whiteSpace: 'nowrap',
+                lineHeight: 1.4,
+            }}
+        >
+            {status}
+        </Box>
+    );
+};

--- a/front-caixinha/src/components/meus-emprestimos/stat-card.tsx
+++ b/front-caixinha/src/components/meus-emprestimos/stat-card.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { Avatar, Box, Card, Stack, Typography } from '@mui/material';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
+import ArrowDownward from '@mui/icons-material/ArrowDownward';
+import type { SvgIconComponent } from '@mui/icons-material';
+
+interface StatCardProps {
+    over: string
+    value: string
+    Icon: SvgIconComponent
+    delta?: number
+    positive?: boolean
+    caption?: string
+}
+
+export const StatCard = ({ over, value, Icon, delta, positive = true, caption }: StatCardProps) => (
+    <Card
+        sx={{
+            p: 3,
+            borderRadius: 5,
+            boxShadow: '0 5px 22px rgba(0,0,0,0.08)',
+        }}
+    >
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1.5}>
+            <Box>
+                <Typography
+                    variant="overline"
+                    sx={{ color: 'text.secondary', letterSpacing: '.5px' }}
+                >
+                    {over}
+                </Typography>
+                <Typography sx={{ fontWeight: 600, fontSize: 30, mt: 0.5, lineHeight: 1.1 }}>
+                    {value}
+                </Typography>
+            </Box>
+            <Avatar sx={{ width: 56, height: 56, bgcolor: 'primary.main' }}>
+                <Icon sx={{ fontSize: 26, color: '#fff' }} />
+            </Avatar>
+        </Stack>
+        {delta != null && (
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 2 }}>
+                <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={0.25}
+                    sx={{ color: positive ? 'success.main' : 'error.main', fontSize: 14 }}
+                >
+                    {positive ? (
+                        <ArrowUpward sx={{ fontSize: 18 }} />
+                    ) : (
+                        <ArrowDownward sx={{ fontSize: 18 }} />
+                    )}
+                    <span>{delta}%</span>
+                </Stack>
+                {caption && (
+                    <Typography sx={{ color: 'text.secondary', fontSize: 12 }}>{caption}</Typography>
+                )}
+            </Stack>
+        )}
+    </Card>
+);

--- a/front-caixinha/src/features/caixinha/utils/flatten-emprestimos.ts
+++ b/front-caixinha/src/features/caixinha/utils/flatten-emprestimos.ts
@@ -1,0 +1,75 @@
+import type { IMeusEmprestimos, LoansForApprove, IBillingDate } from '@/types/types'
+
+export type LoanStatus = 'Pendente' | 'Em dia' | 'Quitado'
+
+export interface EmprestimoView {
+  uid: string
+  caixinha: string
+  valor: number
+  parcelas: number
+  pagas: number
+  proxima: string | null
+  valorParcela: number
+  totalValue: number
+  restante: number
+  status: LoanStatus
+  billingDates: IBillingDate[]
+  raw: LoansForApprove
+}
+
+function paidCount(loan: LoansForApprove): number {
+  const dates = loan.billingDates ?? []
+  if (dates.length) {
+    return dates.filter((b) => b.valor != null).length
+  }
+  return loan.isPaidOff ? loan.parcelas : 0
+}
+
+function nextDueDate(loan: LoansForApprove): string | null {
+  const dates = loan.billingDates ?? []
+  const next = dates.find((b) => b.valor == null)
+  return next?.data ?? null
+}
+
+function toView(loan: LoansForApprove, status: LoanStatus): EmprestimoView {
+  const parcelas = loan.parcelas || (loan.billingDates?.length ?? 1) || 1
+  const pagas = status === 'Quitado' ? parcelas : paidCount(loan)
+  const totalValue = loan.totalValue ?? loan.valueRequested
+  const valorParcela = parcelas > 0 ? totalValue / parcelas : totalValue
+  const restante =
+    loan.remainingAmount ?? Math.max(valorParcela * (parcelas - pagas), 0)
+
+  return {
+    uid: loan.uid,
+    caixinha: loan.caixinha ?? 'Caixinha',
+    valor: loan.valueRequested,
+    parcelas,
+    pagas,
+    proxima: status === 'Quitado' ? null : nextDueDate(loan),
+    valorParcela,
+    totalValue,
+    restante,
+    status,
+    billingDates: loan.billingDates ?? [],
+    raw: loan,
+  }
+}
+
+// Flattens the three per-caixinha loan buckets into a single, status-tagged list
+// used by the master-detail Meus empréstimos screen.
+export function flattenEmprestimos(items: IMeusEmprestimos): EmprestimoView[] {
+  const out: EmprestimoView[] = []
+  for (const caixa of items.caixinhas ?? []) {
+    caixa.emprestimosParaAprovar?.forEach((l) => out.push(toView(l, 'Pendente')))
+    caixa.meusEmprestimos?.forEach((l) => out.push(toView(l, 'Em dia')))
+    caixa.meusEmprestimosQuitados?.forEach((l) => out.push(toView(l, 'Quitado')))
+  }
+  return out
+}
+
+export const brl = (n: number) =>
+  'R$ ' +
+  (n ?? 0).toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })

--- a/front-caixinha/src/pages/index.tsx
+++ b/front-caixinha/src/pages/index.tsx
@@ -1,4 +1,7 @@
 import Layout from "@/components/Layout";
+import { Onboarding } from "@/components/bem-vindo/onboarding";
+import CenteredCircularProgress from "@/components/CenteredCircularProgress";
+import { useSession } from "next-auth/react";
 import { BannerNovidades } from "@/components/bem-vindo/banner-novidades";
 import { Dicas } from "@/components/bem-vindo/dicas";
 import { AtalhoEmprestimo } from "@/components/bem-vindo/atalho-emprestimo";
@@ -179,6 +182,16 @@ const Page = () => {
 }
 
 export default function Home() {
+  const { status } = useSession()
+
+  if (status === 'loading') {
+    return <CenteredCircularProgress />
+  }
+
+  if (status === 'unauthenticated') {
+    return <Onboarding />
+  }
+
   return (
     <Layout>
       <>

--- a/front-caixinha/src/pages/meus-emprestimos/index.tsx
+++ b/front-caixinha/src/pages/meus-emprestimos/index.tsx
@@ -1,56 +1,56 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Button from '@mui/material/Button';
-import Divider from '@mui/material/Divider';
-import Stack from '@mui/material/Stack';
-import SvgIcon from '@mui/material/SvgIcon';
-import Typography from '@mui/material/Typography';
-import { Box, useMediaQuery } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+    Box,
+    Button,
+    Container,
+    InputAdornment,
+    OutlinedInput,
+    Stack,
+    Typography,
+    useMediaQuery,
+} from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { Filter, PlusOneOutlined } from '@mui/icons-material';
-import Layout from '@/components/Layout';
-import { EmprestimosFiltros } from '@/components/meus-emprestimos/filtros';
-import { MeusEmprestmosListContainer } from '@/components/meus-emprestimos/meu-emprestimos-list-container';
-import { MeusEmprestimosListSummary } from '@/components/meus-emprestimos/meus-emprestimos-list-summary';
-import { MeuEmprestimosListTable } from '@/components/meus-emprestimos/meus-emprestimos-table';
+import AddCircleOutline from '@mui/icons-material/AddCircleOutline';
+import AccountBalance from '@mui/icons-material/AccountBalance';
+import HourglassTop from '@mui/icons-material/HourglassTop';
+import PendingActions from '@mui/icons-material/PendingActions';
+import SearchIcon from '@mui/icons-material/Search';
 import { useRouter } from 'next/router';
+import Layout from '@/components/Layout';
+import { Seo } from '@/components/Seo';
 import CenteredCircularProgress from '@/components/CenteredCircularProgress';
 import { useMeusEmprestimos } from '@/features/caixinha/hooks/useMeusEmprestimos';
 import { filterMeusEmprestimos } from '@/features/caixinha/utils/filter-meus-emprestimos';
+import { flattenEmprestimos, brl } from '@/features/caixinha/utils/flatten-emprestimos';
+import { StatCard } from '@/components/meus-emprestimos/stat-card';
+import { EmprestimoListItem } from '@/components/meus-emprestimos/emprestimo-list-item';
+import { EmprestimoDetail } from '@/components/meus-emprestimos/emprestimo-detail';
 
-export default function MeusEmprestimos() {
+const Page = () => {
     const router = useRouter()
     const theme = useTheme()
-    const rootRef = useRef(null);
-    const { items, isLoading, error } = useMeusEmprestimos()
+    const lgUp = useMediaQuery(theme.breakpoints.up('lg'))
 
-    const [filters, setFilters] = useState<{ query?: string }>({})
-    const filteredItems = useMemo(
-        () => filterMeusEmprestimos(items, filters.query ?? ''),
-        [items, filters.query]
+    const { items, isLoading, error } = useMeusEmprestimos()
+    const [query, setQuery] = useState('')
+    const [selected, setSelected] = useState<string | null>(null)
+
+    const allLoans = useMemo(() => flattenEmprestimos(items), [items])
+    const filteredLoans = useMemo(
+        () => flattenEmprestimos(filterMeusEmprestimos(items, query)),
+        [items, query]
     )
 
-    const [group, setGroup] = useState(true);
-
-    const lgUp = useMediaQuery(theme.breakpoints.up('lg'))
-    const [openSidebar, setOpenSidebar] = useState(false)
-
+    // keep a valid selection whenever the filtered list changes
     useEffect(() => {
-        if (lgUp) {
-            setOpenSidebar(true)
+        if (!filteredLoans.length) {
+            setSelected(null)
+            return
         }
-    }, [lgUp])
-
-    const handleGroupChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-        setGroup(event.target.checked);
-    }, []);
-
-    const handleFiltersToggle = useCallback(() => {
-        setOpenSidebar((prevState) => !prevState);
-    }, []);
-
-    const handleFiltersClose = useCallback(() => {
-        setOpenSidebar(false);
-    }, []);
+        if (!selected || !filteredLoans.some((l) => l.uid === selected)) {
+            setSelected(filteredLoans[0].uid)
+        }
+    }, [filteredLoans, selected])
 
     useEffect(() => {
         if (error) {
@@ -59,96 +59,127 @@ export default function MeusEmprestimos() {
     }, [error, router])
 
     if (isLoading) {
-        return <CenteredCircularProgress/>
+        return <CenteredCircularProgress />
+    }
+
+    const emAberto = allLoans.filter((l) => l.status !== 'Quitado').length
+    const selectedLoan = filteredLoans.find((l) => l.uid === selected) ?? filteredLoans[0] ?? null
+
+    const goToDetalhes = (uid: string) => router.push(`/detalhes-emprestimo/${uid}`)
+    const goToRenegociar = (_uid: string) => router.push('/renegociacao')
+    const onItemClick = (uid: string) => {
+        if (lgUp) {
+            setSelected(uid)
+        } else {
+            goToDetalhes(uid)
+        }
     }
 
     return (
-        <Layout>
-            <Divider />
-            <Box
-                component="main"
-                sx={{
-                    display: 'flex',
-                    flex: '1 1 auto',
-                    overflow: 'hidden',
-                    position: 'relative'
-                }}
-            >
+        <Box component="main" sx={{ flexGrow: 1, minHeight: '100vh', py: 5 }}>
+            <Container maxWidth="lg">
+                <Typography variant="overline" sx={{ color: 'text.secondary', letterSpacing: '.5px' }}>
+                    Empréstimos
+                </Typography>
+                <Typography variant="h4" sx={{ fontWeight: 700, mt: 0.5, mb: 3 }}>
+                    Meus empréstimos
+                </Typography>
+
                 <Box
-                    ref={rootRef}
                     sx={{
-                        bottom: 0,
-                        display: 'flex',
-                        left: 0,
-                        position: 'absolute',
-                        right: 0,
-                        top: 0
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+                        gap: 2.5,
+                        mb: 3,
                     }}
                 >
-
-                    <EmprestimosFiltros
-                        container={rootRef.current}
-                        filters={filters}
-                        group={group}
-                        onFiltersChange={setFilters}
-                        onClose={handleFiltersClose}
-                        onGroupChange={handleGroupChange}
-                        open={openSidebar}
-                    />
-                    <MeusEmprestmosListContainer open={openSidebar}>
-                        <Stack spacing={4}>
-                            <Stack
-                                alignItems="flex-start"
-                                direction="row"
-                                justifyContent="space-between"
-                                spacing={3}
-                            >
-                                <div>
-                                    <Typography variant="h4">
-                                        Meus Emprestimos
-                                    </Typography>
-                                </div>
-                                <Stack
-                                    alignItems="center"
-                                    direction="row"
-                                    spacing={1}
-                                >
-                                    <Button
-                                        color="inherit"
-                                        startIcon={(
-                                            <SvgIcon>
-                                                <Filter />
-                                            </SvgIcon>
-                                        )}
-                                        onClick={handleFiltersToggle}
-                                    >
-                                        Filtros
-                                    </Button>
-                                    <Button
-                                        onClick={() => router.push('/emprestimo')}
-                                        startIcon={(
-                                            <SvgIcon>
-                                                <PlusOneOutlined />
-                                            </SvgIcon>
-                                        )}
-                                        variant="contained"
-                                    >
-                                        Novo Emprestimo
-                                    </Button>
-                                </Stack>
-                            </Stack>
-                            <MeusEmprestimosListSummary data={items}/>
-                            <MeuEmprestimosListTable
-                                count={0}
-                                group={group}
-                                items={filteredItems}
-                            />
-                        </Stack>
-                    </MeusEmprestmosListContainer>
-
+                    <StatCard over="Total emprestado" value={brl(items.totalGeral)} Icon={AccountBalance} />
+                    <StatCard over="Empréstimos em aberto" value={String(emAberto)} Icon={HourglassTop} />
+                    <StatCard over="Pendente aprovação" value={brl(items.totalPendente)} Icon={PendingActions} />
                 </Box>
-            </Box>
 
+                {allLoans.length === 0 ? (
+                    <Box
+                        sx={{
+                            textAlign: 'center',
+                            py: 8,
+                            color: 'text.secondary',
+                        }}
+                    >
+                        <Typography sx={{ mb: 2 }}>Você ainda não tem empréstimos.</Typography>
+                        <Button
+                            variant="contained"
+                            startIcon={<AddCircleOutline />}
+                            onClick={() => router.push('/emprestimo')}
+                            sx={{ borderRadius: 3, textTransform: 'none', fontWeight: 600 }}
+                        >
+                            Pedir empréstimo
+                        </Button>
+                    </Box>
+                ) : (
+                    <Box
+                        sx={{
+                            display: 'grid',
+                            gridTemplateColumns: { xs: '1fr', lg: '360px minmax(0, 1fr)' },
+                            gap: 3,
+                            alignItems: 'start',
+                        }}
+                    >
+                        <Stack spacing={1.5}>
+                            <OutlinedInput
+                                fullWidth
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                                placeholder="Buscar empréstimo..."
+                                startAdornment={
+                                    <InputAdornment position="start">
+                                        <SearchIcon fontSize="small" />
+                                    </InputAdornment>
+                                }
+                                sx={{ borderRadius: 2, bgcolor: 'background.paper' }}
+                            />
+                            {filteredLoans.map((e) => (
+                                <EmprestimoListItem
+                                    key={e.uid}
+                                    e={e}
+                                    active={lgUp && e.uid === selectedLoan?.uid}
+                                    onClick={onItemClick}
+                                />
+                            ))}
+                            {filteredLoans.length === 0 && (
+                                <Typography sx={{ color: 'text.secondary', fontSize: 14, py: 2, textAlign: 'center' }}>
+                                    Nenhum empréstimo encontrado.
+                                </Typography>
+                            )}
+                            <Button
+                                variant="text"
+                                startIcon={<AddCircleOutline />}
+                                onClick={() => router.push('/emprestimo')}
+                                sx={{ textTransform: 'none', fontWeight: 600, justifyContent: 'flex-start' }}
+                            >
+                                Pedir novo empréstimo
+                            </Button>
+                        </Stack>
+
+                        {lgUp && selectedLoan && (
+                            <EmprestimoDetail
+                                e={selectedLoan}
+                                onDetails={goToDetalhes}
+                                onRenegociar={goToRenegociar}
+                            />
+                        )}
+                    </Box>
+                )}
+            </Container>
+        </Box>
+    )
+}
+
+export default function MeusEmprestimos() {
+    return (
+        <Layout>
+            <Seo title="Meus empréstimos" />
+            <Page />
         </Layout>
     );
 };


### PR DESCRIPTION
## Resumo

Completa a fidelidade ao design **Indigo** (Claude Design → *Caixinha - Telas (Indigo)*), implementando as telas que ainda não haviam sido redesenhadas. **Nenhuma regra de negócio foi alterada** — hooks, chamadas de API e navegação permanecem intactos (exceto o gate de onboarding, decidido explicitamente).

## Entregas

- **Onboarding / Boas-vindas** (`src/components/bem-vindo/onboarding.tsx` + gate em `src/pages/index.tsx`)
  - Tela standalone mostrada quando o usuário está deslogado; CTAs "Começar agora"/"Já tenho conta" chamam o `signIn()` já existente. Logado → dashboard atual intacto.
- **Meus empréstimos — master-detail** (`src/pages/meus-emprestimos/index.tsx` + componentes em `src/components/meus-emprestimos/`)
  - 3 stat cards, lista clicável com busca, e painel de detalhe (progresso, resumo, parcelas, ações). Util novo `flatten-emprestimos.ts` mapeia `LoansForApprove`/`billingDates` → view-model. Mobile empilha e navega para `/detalhes-emprestimo/{uid}`. Preservados `useMeusEmprestimos`, `filterMeusEmprestimos`, loading/error e navegação real (`/detalhes-emprestimo`, `/renegociacao`, `/emprestimo`).
- **Menu lateral (Drawer indigo)** (`src/components/Drawer.tsx`)
  - Header com logo/capicoin, itens arredondados, item da rota atual destacado; todas as rotas, hrefs, chips e handlers mantidos.
- Docs: `DESIGN_TASKS.md` (tasks 08–10) e `CLAUDE.md` (gotchas + convenções de redesign).

## Verificação

- `npm run build` → exit 0 (todas as rotas compilam).
- Onboarding verificado no browser (renderiza fiel ao design, sem erros de console novos).
- **Limitação:** telas autenticadas (Meus empréstimos, Drawer) não puderam ser dirigidas no browser — auth é OAuth (Keycloak/Google) e não há credenciais no ambiente. Cobertura via build + revisão de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)